### PR TITLE
779 add invoice number to auth.net CIM transaction

### DIFF
--- a/app/models/spree/gateway/authorize_net_cim.rb
+++ b/app/models/spree/gateway/authorize_net_cim.rb
@@ -25,7 +25,8 @@ module Spree
     end
 
     def authorize(amount, creditcard, gateway_options)
-      create_transaction(amount, creditcard, :auth_only)
+      t_options = { :order => {:invoice_number => gateway_options[:order_id] } }
+       create_transaction( amount, creditcard, :auth_only, t_options )
     end
 
     def purchase(amount, creditcard, gateway_options)


### PR DESCRIPTION
I apologize for not including a test. I have tested it extensively in my app against the authnet CIM sandbox.  This should close 779. I have another fix for saving shipping address to gateway but can create a new issue for it.
