### PR TITLE
Fix braintree refunds

### DIFF
--- a/app/models/spree/gateway/braintree.rb
+++ b/app/models/spree/gateway/braintree.rb
@@ -52,7 +52,7 @@ module Spree
       transaction = ::Braintree::Transaction.find(response_code)
       if BigDecimal.new(amount.to_s) == (transaction.amount * 100)
         provider.refund(response_code)
-      elsif BigDecimal.new(amount.to_s) < (transaction.amount * 100)
+      elsif BigDecimal.new(amount.to_s) < (transaction.amount * 100) # support partial refunds
         provider.refund(amount, response_code)
       else
         raise NotImplementedError


### PR DESCRIPTION
Hi Folks,

Braintree now disables credits by default in favor of returns https://www.braintreepayments.com/docs/ruby/transactions/credit

Since braintree uses payment profiles, we had to work a little magic to call the credit_without_payment_profiles method as as the 'credit' action in spree admin. Please consider the changes, thanks!
