### PR TITLE
Fix mass assignment error when updating payment method

### DIFF
--- a/app/models/spree/gateway/authorize_net.rb
+++ b/app/models/spree/gateway/authorize_net.rb
@@ -2,7 +2,9 @@ module Spree
   class Gateway::AuthorizeNet < Gateway
     preference :login, :string
     preference :password, :string
-
+    
+    attr_accessible :preferred_login, :preferred_password
+    
     def provider_class
       ActiveMerchant::Billing::AuthorizeNetGateway
     end

--- a/app/models/spree/gateway/authorize_net_cim.rb
+++ b/app/models/spree/gateway/authorize_net_cim.rb
@@ -4,6 +4,8 @@ module Spree
     preference :password, :string
     preference :test_mode, :boolean, :default => false
     preference :validate_on_profile_create, :boolean, :default => false
+    
+    attr_accessible :preferred_login, :preferred_password, :preferred_test_mode, :preferred_validate_on_profile_create
 
     ActiveMerchant::Billing::Response.class_eval do
       attr_writer :authorization

--- a/app/models/spree/gateway/beanstream.rb
+++ b/app/models/spree/gateway/beanstream.rb
@@ -4,6 +4,8 @@ module Spree
     preference :user, :string
     preference :password, :string
     preference :secure_profile_api_key, :string
+    
+    attr_accessible :preferred_login, :preferred_user, :preferred_password, :preferred_secure_profile_api_key
 
     def provider_class
       ActiveMerchant::Billing::BeanstreamGateway

--- a/app/models/spree/gateway/braintree.rb
+++ b/app/models/spree/gateway/braintree.rb
@@ -3,6 +3,8 @@ module Spree
     preference :merchant_id, :string
     preference :public_key, :string
     preference :private_key, :string
+    
+    attr_accessible :preferred_merchant_id, :preferred_public_key, :preferred_private_key
 
     def provider_class
       ActiveMerchant::Billing::BraintreeGateway

--- a/app/models/spree/gateway/eway.rb
+++ b/app/models/spree/gateway/eway.rb
@@ -1,6 +1,8 @@
 module Spree
   class Gateway::Eway < Gateway
     preference :login, :string
+    
+    attr_accessible :preferred_login
 
     # Note: EWay supports purchase method only (no authorize method).
     # Ensure Spree::Config[:auto_capture] is set to true

--- a/app/models/spree/gateway/linkpoint.rb
+++ b/app/models/spree/gateway/linkpoint.rb
@@ -2,6 +2,8 @@ module Spree
   class Gateway::Linkpoint < Gateway
     preference :login, :string
     preference :pem, :text
+    
+    attr_accessible :preferred_login, :preferred_pem
 
     def provider_class
       ActiveMerchant::Billing::LinkpointGateway

--- a/app/models/spree/gateway/pay_pal.rb
+++ b/app/models/spree/gateway/pay_pal.rb
@@ -4,6 +4,8 @@ module Spree
     preference :password, :string
     preference :signature, :string
     preference :currency_code, :string
+    
+    attr_accessible :preferred_login, :preferred_password, :preferred_signature, :preferred_currency_code
 
     def provider_class
       ActiveMerchant::Billing::PaypalGateway

--- a/app/models/spree/gateway/sage_pay.rb
+++ b/app/models/spree/gateway/sage_pay.rb
@@ -3,6 +3,8 @@ module Spree
     preference :login, :string
     preference :password, :string
     preference :account, :string
+    
+    attr_accessible :preferred_login, :preferred_password, :preferred_account
 
     def provider_class
       ActiveMerchant::Billing::SagePayGateway

--- a/app/models/spree/gateway/samurai.rb
+++ b/app/models/spree/gateway/samurai.rb
@@ -3,6 +3,8 @@ module Spree
     preference :login, :string
     preference :password, :string
     preference :processor_token, :string
+    
+    attr_accessible :preferred_login, :preferred_password, :preferred_processor_token
 
     # Make sure to have Spree::Config[:auto_capture] set to true.
 

--- a/app/models/spree/gateway/stripe.rb
+++ b/app/models/spree/gateway/stripe.rb
@@ -1,6 +1,8 @@
 module Spree
   class Gateway::Stripe < Gateway
     preference :login, :string
+    
+    attr_accessible :preferred_login
 
     # Make sure to have Spree::Config[:auto_capture] set to true.
 


### PR DESCRIPTION
Due to mass assignment changes in rails 3.2.3 we need to add any preferences to attr_accessible otherwise we get a mass assignment error when trying to update payment methods.

This should fix Issue #1386 in spree when used in conjunction with my [pull request in spree](https://github.com/spree/spree/pull/1393)
