### PR TITLE
Use Bundler gem tasks rather than the Rubygems package tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,26 +1,11 @@
 require 'rake'
-require 'rake/testtask'
-require 'rake/packagetask'
-require 'rubygems/package_task'
 require 'rspec/core/rake_task'
 require 'spree/core/testing_support/common_rake'
+require 'bundler/gem_tasks'
 
 RSpec::Core::RakeTask.new
 
 task :default => [:spec]
-
-spec = eval(File.read('spree_gateway.gemspec'))
-
-Gem::PackageTask.new(spec) do |p|
-  p.gem_spec = spec
-end
-
-desc "Release to gemcutter"
-task :release => :package do
-  require 'rake/gemcutter'
-  Rake::Gemcutter::Tasks.new(spec).define
-  Rake::Task['gem:push'].invoke
-end
 
 desc "Generates a dummy app for testing"
 task :test_app do


### PR DESCRIPTION
Trying to build the gem using `rake gem` fails as follows:

```
mkdir -p pkg
cd pkg/spree_gateway-1.0.0
rake aborted!
No such file or directory - pkg/spree_gateway-1.0.0

Tasks: TOP => gem => pkg/spree_gateway-1.0.0.gem
(See full trace by running task with --trace)
```

It seems like the Rubygems/Gemcutter rake tasks are a little long in the tooth. The Bundler tasks work a treat, and I can now use `rake build` to spit out a gem.

The new Rake tasks are `build` to build the gem, `install` to build and install the gem, and `release` to tag, build and push the gem out.
