### PR TITLE
Clarify Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,19 +3,29 @@ SpreeGateway
 
 Community supported Spree Payment Method Gateways. 
 
-These can be used with Spree 1.0.x
+These can be used with Spree 1.0.x (but see note below for necessary changes)
 
 http://guides.spreecommerce.com/payment_gateways.html
 
 Installation
 =======
 
-In your gemfile:
+In your Gemfile:
 
-gem 'spree'
-gem 'spree_gateway' # make sure to include after spree
+    gem 'spree'
+	gem 'spree_gateway', :git => "https://github.com/spree/spree_gateway.git" # make sure to include after spree
 
-bundle install
+Then run from the command line:
+
+	bundle install
+	rails g spree_gateway:install
+
+Finally, make sure to **restart your app**. Navigate to *configuration > payment methods > new payment method*  in the admin panel and you should see that a bunch of additional gateways have been added to the list.
+
+##### Note
+If you are using Spree 1.0.x,  you will need to load `spree_gateway` in your Gemfile as below, or override the payment_method model and add `attr_accessible :name, :description, :environment, :display_on, :active, :type`. If you do not make one of these modifications, **it will not work** when adding new payment methods.
+
+     gem 'spree_gateway', :git => 'git://github.com/spree/spree_gateway.git', :ref => 'e0aa8bfbb7c26786b276d1a3eaa9820c1aa08c79'
 
 Testing
 -------


### PR DESCRIPTION
There was a bunch of information missing in the readme and the install instructions were unclear and incomplete. This commit modifies the readme to make it much more clear and highlights issues with Spree 1.0.x and how to fix them.

-- Fixes #10
