### PR TITLE
undefined method gateway_error

### DIFF
--- a/app/models/spree/gateway/stripe.rb
+++ b/app/models/spree/gateway/stripe.rb
@@ -1,7 +1,7 @@
 module Spree
   class Gateway::Stripe < Gateway
     preference :login, :string
-    
+
     attr_accessible :preferred_login
 
     # Make sure to have Spree::Config[:auto_capture] set to true.
@@ -50,7 +50,7 @@ module Spree
       if response.success?
         payment.source.update_attributes!(:gateway_customer_profile_id => response.params['id'])
       else
-        payment.source.gateway_error(response.message)
+        raise ActiveMerchant::ConnectionError, response.message
       end
     end
   end


### PR DESCRIPTION
I'm using latest version of spree and Stripe. After changes in this commit https://github.com/spree/spree/commit/47b2884767e45fed8f92ecc16e96c72a348e6f50 this gem become broken and seems that doesn't work. I had no time to dig deeper in this problem, may be it needs some arhitecture changes but this fix resolved my problem and everything works fine for me now. 
May be it needed other branch, than master
