### PR TITLE
Add stripe gateway support for token-based charges

### DIFF
--- a/app/models/spree/gateway/stripe.rb
+++ b/app/models/spree/gateway/stripe.rb
@@ -20,6 +20,9 @@ module Spree
       if customer = creditcard.gateway_customer_profile_id
         options[:customer] = customer
         creditcard = nil
+      elsif token = creditcard.gateway_payment_profile_id
+        # The Stripe ActiveMerchant gateway supports passing the token directly as the creditcard parameter
+        creditcard = token
       end
       provider.purchase(money, creditcard, options)
     end


### PR DESCRIPTION
Stripe supports a Javascript API where the credit card number never
touches our app servers, but instead we get back a token to use to
make the charge.  The token is roughly equivalent to a payment "id"
so I use the gateway_payment_profile_id field for this.
