### PR TITLE
[Fixes #18] - For BeanStream: creditcard.source does not exist

### DIFF
--- a/app/models/spree/gateway/beanstream.rb
+++ b/app/models/spree/gateway/beanstream.rb
@@ -24,8 +24,7 @@ module Spree
         if result.success?
           creditcard.update_attributes(:gateway_customer_profile_id => result.params['customerCode'], :gateway_payment_profile_id => result.params['customer_vault_id'])
         else
-          creditcard.gateway_error(result) if creditcard.respond_to? :gateway_error
-          creditcard.source.gateway_error(result)
+          payment.send(:gateway_error, result)
         end
       end
     end


### PR DESCRIPTION
fixes a syntax error for BeanStream
