### PR TITLE
[Fixes #20] - undefined method type for credit card - beanstream

### DIFF
--- a/app/models/spree/gateway/beanstream.rb
+++ b/app/models/spree/gateway/beanstream.rb
@@ -164,7 +164,12 @@ module Spree
           if source.is_a?(String) or source.is_a?(Integer)
             post[:customerCode] = source
           else
-            source.type.to_s == 'check' ? add_check(post, source) : add_credit_card(post, source)
+            if (defined? Spree::Creditcard) && source.kind_of?(Spree::Creditcard) ||
+               (defined? Spree::CreditCard) && source.kind_of?(Spree::CreditCard)
+              add_credit_card(post, source)
+            elsif source.type.to_s == 'check'
+              add_check(post, source)
+            end
           end
         end
 


### PR DESCRIPTION
I tried to future-proof this since Spree::Creditcard has been recently renamed (and we don't yet have any branches in this repo).  

Thoughts on my approach?  I'm not familiar with how checks work in beanstream, so I left that part as-is in the elsif clause.
