### PR TITLE
Creditcards do not have STI and no type.

### DIFF
--- a/app/models/spree/gateway/beanstream.rb
+++ b/app/models/spree/gateway/beanstream.rb
@@ -163,7 +163,7 @@ module Spree
           if source.is_a?(String) or source.is_a?(Integer)
             post[:customerCode] = source
           else
-            if source.responds_to?(:type) && source.type.to_s == 'check'
+            if source.respond_to?(:type) && source.type.to_s == 'check'
               add_check(post, source)
             else
               add_credit_card(post, source)


### PR DESCRIPTION
When the source is a Spree::Creditcard and error would get thrown, `undefined method type for Spree::Creditcard`.

Added a check to see if the source responds to type.
