### PR TITLE
Stripe credit method should use provider.refund

### DIFF
--- a/app/models/spree/gateway/stripe.rb
+++ b/app/models/spree/gateway/stripe.rb
@@ -36,7 +36,7 @@ module Spree
     end
 
     def credit(money, creditcard, response_code, gateway_options)
-      provider.credit(money, response_code, {})
+      provider.refund(money, response_code, {})
     end
 
     def void(response_code, gateway_options)


### PR DESCRIPTION
provider.credit doesn't seem to be valid under active merchant 1.20.4. Simply changing the line to provider.refund seems to work.
