### PR TITLE
adds support for Braintree's client side encryption

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,11 @@ source 'http://rubygems.org'
 
 group :test do
   gem 'ffaker'
+  gem 'sqlite3'
+  gem 'factory_girl'
 end
+gem 'activemerchant', '1.28.0'
+gem 'braintree'
 
 if RUBY_VERSION < "1.9"
   gem "ruby-debug"


### PR DESCRIPTION
These are a few changes to support using client side encryption with Braintree.  This also works with ActiveMerchant 1.28.0

I'm having significant problems running the braintree specs after merging with the latest spree gateway, but the tests are marked pending in master anyway.
