### PR TITLE
Fix Stripe void

### DIFF
--- a/app/models/spree/gateway/stripe.rb
+++ b/app/models/spree/gateway/stripe.rb
@@ -39,7 +39,7 @@ module Spree
       provider.refund(money, response_code, {})
     end
 
-    def void(response_code, gateway_options)
+    def void(response_code, creditcard, gateway_options)
       provider.void(response_code, {})
     end
 


### PR DESCRIPTION
stripe supports payment_profiles_supported? so void will get 3 paramters... of which it should ignore 2
