### PR TITLE
Make stripe works with  canadian based shop.

### DIFF
--- a/app/models/spree/gateway/stripe.rb
+++ b/app/models/spree/gateway/stripe.rb
@@ -1,8 +1,9 @@
 module Spree
   class Gateway::Stripe < Gateway
     preference :login, :string
-    
-    attr_accessible :preferred_login
+    preference :currency, :string, :default => 'USD'        #stripes only supports USD and CAD
+
+    attr_accessible :preferred_login, :preferred_currency
 
     # Make sure to have Spree::Config[:auto_capture] set to true.
 
@@ -17,6 +18,7 @@ module Spree
     def purchase(money, creditcard, gateway_options)
       options = {}
       options[:description] = "Spree Order ID: #{gateway_options[:order_id]}"
+      options[:currency] = preferred_currency
       if customer = creditcard.gateway_customer_profile_id
         options[:customer] = customer
         creditcard = nil


### PR DESCRIPTION
 That fix creates a new preference `currency` which allows to specify the currency in which the transaction should take place. 
Default is set to 'USD'.  If you want to use Canadian dollar, CAD should be used
This was tested using the test API from stripe for a canadian based shop
