### PR TITLE
splat the ignored options in #void 

### DIFF
--- a/app/models/spree/gateway/braintree.rb
+++ b/app/models/spree/gateway/braintree.rb
@@ -69,7 +69,7 @@ module Spree
       authorize(money, creditcard, options.merge(:submit_for_settlement => true))
     end
 
-    def void(response_code, ignored_options)
+    def void(response_code, *ignored_options)
       provider.void(response_code)
     end
 


### PR DESCRIPTION
This is needed because Spree 1.2.0 calls the void method with 3 arguments.
