### PR TITLE
Store the Braintree credit card token to allow credit card reuse

### DIFF
--- a/app/models/spree/gateway/braintree_gateway.rb
+++ b/app/models/spree/gateway/braintree_gateway.rb
@@ -39,6 +39,7 @@ module Spree
     def update_card_number(source, cc)
       last_4 = cc['last_4']
       source.last_digits = last_4 if last_4
+      source.gateway_payment_profile_id = cc['token']
       masked_number = cc['masked_number']
       if masked_number
         source.cc_type = nil


### PR DESCRIPTION
This is necessary to allow spree_reuse_credit_card to work with Braintree.
