### PR TITLE
Fixing spelling mistake for worldpay attr_accessible attribute 

### DIFF
--- a/app/models/spree/gateway/data_cash.rb
+++ b/app/models/spree/gateway/data_cash.rb
@@ -1,0 +1,12 @@
+module Spree
+  class Gateway::DataCash < Gateway
+    preference :login, :string
+    preference :password, :string
+
+    attr_accessible :preferred_login, :preferred_password
+
+    def provider_class
+      ActiveMerchant::Billing::DataCashGateway
+    end
+  end
+end

--- a/lib/spree_gateway/engine.rb
+++ b/lib/spree_gateway/engine.rb
@@ -27,6 +27,7 @@ module SpreeGateway
         app.config.spree.payment_methods << Spree::Gateway::UsaEpay
         app.config.spree.payment_methods << Spree::BillingIntegration::Skrill::QuickCheckout
         app.config.spree.payment_methods << Spree::Gateway::BalancedGateway
+        app.config.spree.payment_methods << Spree::Gateway::DataCash
     end
   end
 


### PR DESCRIPTION
Changing attr_accessible prefered_discover_login to include second r, so that worldpay payment methods can be created / updated
