### PR TITLE
Send bill address to Stripe when creating profile

### DIFF
--- a/app/models/spree/gateway/stripe_gateway.rb
+++ b/app/models/spree/gateway/stripe_gateway.rb
@@ -61,6 +61,8 @@ module Spree
       end
     end
 
+    private
+
     def address_for(payment)
       {}.tap do |options|
         if address = payment.order.bill_address

--- a/spec/models/gateway/stripe_gateway_spec.rb
+++ b/spec/models/gateway/stripe_gateway_spec.rb
@@ -1,14 +1,23 @@
 require 'spec_helper'
 
 describe Spree::Gateway::StripeGateway do
+  let(:login) { 'nothing' }
+  let(:email) { 'customer@example.com' }
+
   let(:payment) {
     stub('Spree::Payment',
-      order: stub('Spree::Order', bill_address: bill_address)
+      source: stub('Source', gateway_customer_profile_id: nil).as_null_object,
+      order: stub('Spree::Order',
+        email: email,
+        bill_address: bill_address
+      )
     )
   }
 
-  describe '#address_for' do
-    context 'order with bill address' do
+  before { subject.set_preference :login, login }
+
+  describe '#create_profile' do
+    context 'with an order that has a bill address' do
       let(:bill_address) {
         stub('Spree::Address',
           address1: '123 Happy Road',
@@ -20,8 +29,11 @@ describe Spree::Gateway::StripeGateway do
         )
       }
 
-      it 'returns the bill address from the order' do
-        expect(subject.address_for payment).to eq({
+      it 'stores the bill address with the provider' do
+        subject.provider.should_receive(:store).with(payment.source, {
+          email: email,
+          login: login,
+
           address: {
             address1: '123 Happy Road',
             address2: 'Apt 303',
@@ -30,15 +42,22 @@ describe Spree::Gateway::StripeGateway do
             state: 'Oregon',
             country: 'United States'
           }
-        })
+        }).and_return stub.as_null_object
+
+        subject.create_profile payment
       end
     end
 
-    context 'order without a bill address' do
+    context 'with an order that does not have a bill address' do
       let(:bill_address) { nil }
 
-      it 'returns an empty hash' do
-        expect(subject.address_for payment).to eq({})
+      it 'does not store a bill address with the provider' do
+        subject.provider.should_receive(:store).with(payment.source, {
+          email: email,
+          login: login,
+        }).and_return stub.as_null_object
+
+        subject.create_profile payment
       end
     end
   end


### PR DESCRIPTION
Sending the address to Stripe when creating customers is important because this information is required if you want to validate the billing zip code. This also gives leverage when dealing with chargeback/fraud claims.
