### PR TITLE
Added pay_to_email in the config and to the skrill request

### DIFF
--- a/app/models/spree/billing_integration/skrill/quick_checkout.rb
+++ b/app/models/spree/billing_integration/skrill/quick_checkout.rb
@@ -22,7 +22,7 @@ module Spree
       opts[:detail1_text] = order.number
       opts[:detail1_description] = "Order:"
 
-      #opts[:pay_from_email] = order.email
+      opts[:pay_from_email] = order.email
       opts[:firstname] = order.bill_address.firstname
       opts[:lastname] = order.bill_address.lastname
       opts[:address] = order.bill_address.address1


### PR DESCRIPTION
Based on the skrill manual all requests to the gateway should be including the merchants email (pay_to_email parameter) merchant_id might be discontinued by skrill 
The pay_to_email is now added to the config and also to the request and will resolve any issues related to the gateway not loading  
