### PR TITLE
Fix Linkpoint gateway to sum the discount and subtotal

### DIFF
--- a/app/models/spree/gateway/linkpoint.rb
+++ b/app/models/spree/gateway/linkpoint.rb
@@ -6,5 +6,23 @@ module Spree
     def provider_class
       ActiveMerchant::Billing::LinkpointGateway
     end
+
+    [:authorize, :purchase, :capture, :void, :credit].each do |method|
+      define_method(method) do |*args|
+        options = add_discount_to_subtotal(args.extract_options!)
+        provider.public_send(method, *args << options)
+      end
+    end
+
+    private
+
+    # Linkpoint ignores the discount, but it will return an error if the
+    # chargetotal is different from the sum of the subtotal, tax and
+    # shipping totals.
+    def add_discount_to_subtotal(options)
+      subtotal = options.fetch(:subtotal)
+      discount = options.fetch(:discount)
+      options.merge(subtotal: subtotal + discount, discount: 0)
+    end
   end
 end

--- a/spec/models/gateway/linkpoint_spec.rb
+++ b/spec/models/gateway/linkpoint_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+describe Spree::Gateway::Linkpoint do
+  let(:gateway) { Spree::Gateway::Linkpoint.create!(:name => "Linkpoint") }
+  let(:provider) { double('provider') }
+  let(:money) { double('money') }
+  let(:credit_card) { double('credit_card') }
+  let(:identification) { double('identification') }
+  let(:options) { { subtotal: 3, discount: -1 } }
+
+  before do
+    gateway.provider_class.stub(new: provider)
+  end
+
+  it "should be Linkpoint gateway" do
+    gateway.provider_class.should == ::ActiveMerchant::Billing::LinkpointGateway
+  end
+
+  describe "#authorize" do
+    it "adds the discount to the subtotal" do
+      provider.should_receive(:authorize)
+        .with(money, credit_card, subtotal: 2, discount: 0)
+      gateway.authorize(money, credit_card, options)
+    end
+  end
+
+  describe "#purchase" do
+    it "adds the discount to the subtotal" do
+      provider.should_receive(:purchase)
+        .with(money, credit_card, subtotal: 2, discount: 0)
+      gateway.purchase(money, credit_card, options)
+    end
+  end
+
+  describe "#capture" do
+    let(:authorization) { double('authorization') }
+
+    it "adds the discount to the subtotal" do
+      provider.should_receive(:capture)
+        .with(money, authorization, subtotal: 2, discount: 0)
+      gateway.capture(money, authorization, options)
+    end
+  end
+
+  describe "#void" do
+    it "adds the discount to the subtotal" do
+      provider.should_receive(:void)
+        .with(identification, subtotal: 2, discount: 0)
+      gateway.void(identification, options)
+    end
+  end
+
+  describe "#credit" do
+    it "adds the discount to the subtotal" do
+      provider.should_receive(:credit)
+        .with(money, identification, subtotal: 2, discount: 0)
+      gateway.credit(money, identification, options)
+    end
+  end
+end


### PR DESCRIPTION
The Linkpoint gateway requires that the subtotal, tax and shipping equal the payment total. It completely ignores the discount provided, which could be the result of a promo code.

This branch adds the discount to the subtotal, and sets the discount to 0. While not strictly necessary to set to 0, I did not want to remove it completely since it breaks the contract already established that the gateway options include a discount key.
