### PR TITLE
Rename PayPal to PayPalGateway to avoid namespacing issue

### DIFF
--- a/app/models/spree/gateway/pay_pal_gateway.rb
+++ b/app/models/spree/gateway/pay_pal_gateway.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::PayPal < Gateway
+  class Gateway::PayPalGateway < Gateway
     preference :login, :string
     preference :password, :string
     preference :signature, :string

--- a/db/migrate/20131008221012_update_paypal_payment_method_type.rb
+++ b/db/migrate/20131008221012_update_paypal_payment_method_type.rb
@@ -1,0 +1,9 @@
+class UpdatePaypalPaymentMethodType < ActiveRecord::Migration
+  def up
+    Spree::PaymentMethod.where(:type => "Spree::Gateway::PayPal").update_all(:type => "Spree::Gateway::PayPalGateway")
+  end
+  
+  def down
+    Spree::PaymentMethod.where(:type => "Spree::Gateway::PayPalGateway").update_all(:type => "Spree::Gateway::PayPal")
+  end
+end

--- a/lib/spree_gateway/engine.rb
+++ b/lib/spree_gateway/engine.rb
@@ -18,7 +18,7 @@ module SpreeGateway
         app.config.spree.payment_methods << Spree::Gateway::Linkpoint
         app.config.spree.payment_methods << Spree::Gateway::Moneris
         app.config.spree.payment_methods << Spree::Gateway::PayJunction
-        app.config.spree.payment_methods << Spree::Gateway::PayPal
+        app.config.spree.payment_methods << Spree::Gateway::PayPalGateway
         app.config.spree.payment_methods << Spree::Gateway::SagePay
         app.config.spree.payment_methods << Spree::Gateway::Beanstream
         app.config.spree.payment_methods << Spree::Gateway::BraintreeGateway


### PR DESCRIPTION
fixes "undefined method `new' for PayPal:Module error" in 
https://github.com/spree/spree_paypal_express/issues/158
