### PR TITLE
Stripe gateway was disabling the billing name from being submitted

### DIFF
--- a/app/assets/javascripts/store/gateway/stripe.js.coffee
+++ b/app/assets/javascripts/store/gateway/stripe.js.coffee
@@ -33,8 +33,4 @@ stripeResponseHandler = (status, response) ->
     # insert the token into the form so it gets submitted to the server
     paymentMethodId = Spree.stripePaymentMethod.prop('id').split("_")[2]
     Spree.stripePaymentMethod.append("<input type='hidden' class='stripeToken' name='payment_source[" + paymentMethodId  + "][gateway_payment_profile_id]' value='" + token + "'/>");
-    # insert additional card info to save to the payment source
-    expiration = $('.cardExpiry:visible').payment('cardExpiryVal')
-    Spree.stripePaymentMethod.append("<input type='hidden' name='payment_source[" + paymentMethodId + "][month]' value='" + expiration.month + "'/>");
-    Spree.stripePaymentMethod.append("<input type='hidden' name='payment_source[" + paymentMethodId + "][year]' value='" + expiration.year + "'/>");
     Spree.stripePaymentMethod.parents("form").get(0).submit();


### PR DESCRIPTION
The first and last name hidden fields were being disabled, so the card info was not being saved.

So I'm wondering, what's the best way to save the additional information (exp and last four digits) to the created `Spree::CreditCard` record while maintaining the security of Stripe and only passing the token?

I'm still pretty new to Spree, so I haven't figured out when the card gets authorized other than when Stripe.js generates the token. 

So what I need help with is knowing when the Stripe customer data (exp and last four digits) can be saved to the `Spree::CreditCard`. Do we pull it in from Stripe when the card gets saved? Do we send it with the form?
