### PR TITLE
New Swipe Gateway

### DIFF
--- a/app/models/spree/gateway/swipe_gateway.rb
+++ b/app/models/spree/gateway/swipe_gateway.rb
@@ -1,0 +1,12 @@
+module Spree
+  class Gateway::SwipeGateway < Gateway
+    preference :login, :string
+    preference :api_key, :string
+    preference :region, :string
+
+    def provider_class
+      ActiveMerchant::Billing::SwipeCheckoutGateway
+    end
+
+  end
+end

--- a/app/models/spree/gateway/swipe_gateway.rb
+++ b/app/models/spree/gateway/swipe_gateway.rb
@@ -12,5 +12,11 @@ module Spree
     def auto_capture?
       true
     end
+
+    def purchase(money, creditcard, gateway_options)
+      gateway_options[:description] = "Spree Checkout - Order " + gateway_options[:order_id]
+      money = money.to_f / 100
+      provider.purchase(money, creditcard, gateway_options)
+    end
   end
 end

--- a/app/models/spree/gateway/swipe_gateway.rb
+++ b/app/models/spree/gateway/swipe_gateway.rb
@@ -8,5 +8,9 @@ module Spree
       ActiveMerchant::Billing::SwipeCheckoutGateway
     end
 
+    # (no authorize method).
+    def auto_capture?
+      true
+    end
   end
 end

--- a/lib/spree_gateway/engine.rb
+++ b/lib/spree_gateway/engine.rb
@@ -35,6 +35,7 @@ module SpreeGateway
         app.config.spree.payment_methods << Spree::Gateway::Paymill
         app.config.spree.payment_methods << Spree::Gateway::PayflowPro
         app.config.spree.payment_methods << Spree::Gateway::SecurePayAU
+        app.config.spree.payment_methods << Spree::Gateway::SwipeGateway
     end
   end
 

--- a/spec/models/gateway/swipe_gateway_spec.rb
+++ b/spec/models/gateway/swipe_gateway_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe Spree::Gateway::SwipeGateway do
+
+  before(:each) do
+    Spree::Gateway.update_all :active => false
+    @gateway = Spree::Gateway::SwipeGateway.create!(:name => "Swipe Gateway", :environment => "sandbox", :active => true)
+
+    @gateway.set_preference(:login, "2077103073D8B5")
+    @gateway.set_preference(:api_key, "f2fe4efd5033edfaed9e4aad319ef4d34536a10eea07f90f182616d7216ae2b8")
+    @gateway.set_preference(:region, "NZ")
+    @gateway.save!
+
+    @country = FactoryGirl.create(:country, :name => "New Zealand", :iso_name => "New Zealand", :iso3 => "NZD", :iso => "NZ", :numcode => 61)
+    @state   = FactoryGirl.create(:state, :name => "Canterbury", :abbr => "CAN", :country => @country)
+    @address = FactoryGirl.create(:address,
+      :firstname => 'Ronald C',
+      :lastname => 'Robot',
+      :address1 => '1234 My Street',
+      :address2 => 'Apt 1',
+      :city =>  'Christchurch',
+      :zipcode => '8000',
+      :phone => '88888888',
+      :state => @state,
+      :country => @country
+    )
+    @order = FactoryGirl.create(:order_with_totals, :bill_address => @address, :ship_address => @address)
+    @order.update!
+    @credit_card = FactoryGirl.create(:credit_card, 
+      :verification_value => '123',
+      :number => '1234123412341234',
+      :cc_type => :visa,
+      :month => 5,
+      :year => Time.now.year + 1,
+      :first_name => 'Ronald C',
+      :last_name => 'Robot'
+    )
+    @payment = FactoryGirl.create(:payment, 
+      :source => @credit_card,
+      :order => @order,
+      :payment_method => @gateway, :amount => 10.00)
+    @payment.payment_method.environment = "test"
+
+
+  end
+
+  it "can purchase" do
+    @payment.purchase!
+    @payment.state.should == 'completed'
+  end
+end


### PR DESCRIPTION
I have the spec test passing and submitting successfully server side, but when trying to use this gateway in the checkout process within Spree I'm running into a bit of brick wall. Any help/guidance would be so appreciated.

When I attempt to use the checkout option in the actual cart I get the error:

That payment method is unsupported. Please choose another one.

Without knowing too much about the spree core all I could find out through debugging is that within source passed to payment_method.supports? on line 8 of :cc_type => nil at the time it is processed. And changing this to a brand allows it to pass successfully pass the "supports?" method.

https://github.com/spree/spree/blob/master/core/app/models/spree/payment/processing.rb?source=cc#L8

Swipe requires the card brand in order to successfully 
