### PR TITLE
add support for braintree merchant account id

### DIFF
--- a/app/models/spree/gateway/braintree_gateway.rb
+++ b/app/models/spree/gateway/braintree_gateway.rb
@@ -2,6 +2,7 @@ module Spree
   class Gateway::BraintreeGateway < Gateway
     preference :environment, :string
     preference :merchant_id, :string
+    preference :merchant_account_id, :string
     preference :public_key, :string
     preference :private_key, :string
     preference :client_side_encryption_key, :text
@@ -109,6 +110,7 @@ module Spree
 
     def preferences
       preferences = super.slice(:merchant_id,
+                                :merchant_account_id,
                                 :public_key,
                                 :private_key,
                                 :client_side_encryption_key,
@@ -129,6 +131,9 @@ module Spree
       end
 
       def adjust_options_for_braintree(creditcard, options)
+        if preferred_merchant_account_id
+          options['merchant_account_id'] = preferred_merchant_account_id
+        end        
         adjust_billing_address(creditcard, options)
       end
   end

--- a/spec/models/gateway/braintree_gateway_spec.rb
+++ b/spec/models/gateway/braintree_gateway_spec.rb
@@ -35,6 +35,31 @@ describe Spree::Gateway::BraintreeGateway do
 
   end
 
+  describe 'merchant_account_id' do
+    context 'with merchant_account_id set on gateway' do
+      let(:merchant_account_id) { 'test' }
+
+      before do
+        @gateway.set_preference(:merchant_account_id, merchant_account_id)
+      end
+
+      it 'should have a perferred_merchant_account_id' do
+        @gateway.preferred_merchant_account_id.should == merchant_account_id
+      end
+
+      it 'should have a preferences[:merchant_account_id]' do
+        @gateway.preferences.keys.include?(:merchant_account_id).should be_true
+      end
+      
+      it 'should adjust options to include merchant_account_id' do
+        options = {}
+        @gateway.should_receive(:adjust_billing_address).once
+        @gateway.send(:adjust_options_for_braintree, double, options)
+        options['merchant_account_id'].should == merchant_account_id
+      end
+    end
+  end
+
   it "should be braintree gateway" do
     @gateway.provider_class.should == ::ActiveMerchant::Billing::BraintreeBlueGateway
   end


### PR DESCRIPTION
This adds support for Braintree merchant_account_id.

High Level Description
https://support.braintreepayments.com/customer/portal/articles/1080468-merchant-id-vs-merchant-account-id-what’s-the-difference-

API
https://www.braintreepayments.com/docs/ruby/transactions/create
