### PR TITLE
Handle preferred_merchant_account_id empty string

### DIFF
--- a/app/models/spree/gateway/braintree_gateway.rb
+++ b/app/models/spree/gateway/braintree_gateway.rb
@@ -131,7 +131,7 @@ module Spree
       end
 
       def adjust_options_for_braintree(creditcard, options)
-        if preferred_merchant_account_id
+        unless preferred_merchant_account_id.blank?
           options['merchant_account_id'] = preferred_merchant_account_id
         end        
         adjust_billing_address(creditcard, options)

--- a/spec/models/gateway/braintree_gateway_spec.rb
+++ b/spec/models/gateway/braintree_gateway_spec.rb
@@ -36,12 +36,24 @@ describe Spree::Gateway::BraintreeGateway do
   end
 
   describe 'merchant_account_id' do
+
+    before do
+      @gateway.set_preference(:merchant_account_id, merchant_account_id)
+    end
+
+    context "the merchant account id is an empty string" do
+      let(:merchant_account_id) { "" }
+
+      it 'should not set the merchant_account_id' do
+        options = {}
+        @gateway.should_receive(:adjust_billing_address).once
+        @gateway.send(:adjust_options_for_braintree, double, options)
+        options['merchant_account_id'].should be_nil
+      end
+    end
+
     context 'with merchant_account_id set on gateway' do
       let(:merchant_account_id) { 'test' }
-
-      before do
-        @gateway.set_preference(:merchant_account_id, merchant_account_id)
-      end
 
       it 'should have a perferred_merchant_account_id' do
         @gateway.preferred_merchant_account_id.should == merchant_account_id


### PR DESCRIPTION
Colleague found an issue where truthy empty string was being passed to Braintree. This should address.
