### PR TITLE
Fix for Feature/braintree merchant account

### DIFF
--- a/app/models/spree/gateway/braintree_gateway.rb
+++ b/app/models/spree/gateway/braintree_gateway.rb
@@ -108,6 +108,16 @@ module Spree
       provider.void(response_code)
     end
 
+    def options
+      h = super
+      # We need to add merchant_account_id only if present when creating BraintreeBlueGateway
+      # Remove it since it is always part of the preferences hash.
+      if h[:merchant_account_id].blank?
+        h.delete(:merchant_account_id) 
+      end 
+      h
+    end
+
     def preferences
       preferences = super.slice(:merchant_id,
                                 :merchant_account_id,
@@ -131,9 +141,6 @@ module Spree
       end
 
       def adjust_options_for_braintree(creditcard, options)
-        if preferred_merchant_account_id
-          options['merchant_account_id'] = preferred_merchant_account_id
-        end        
         adjust_billing_address(creditcard, options)
       end
   end

--- a/spec/models/gateway/braintree_gateway_spec.rb
+++ b/spec/models/gateway/braintree_gateway_spec.rb
@@ -36,12 +36,20 @@ describe Spree::Gateway::BraintreeGateway do
   end
 
   describe 'merchant_account_id' do
+    before do
+      @gateway.set_preference(:merchant_account_id, merchant_account_id)
+    end
+
+    context "with merchant_account_id empty" do
+      let(:merchant_account_id) { "" }
+
+      it 'should not be present in options' do
+        @gateway.options.keys.include?(:merchant_account_id).should be_false
+      end
+    end
+
     context 'with merchant_account_id set on gateway' do
       let(:merchant_account_id) { 'test' }
-
-      before do
-        @gateway.set_preference(:merchant_account_id, merchant_account_id)
-      end
 
       it 'should have a perferred_merchant_account_id' do
         @gateway.preferred_merchant_account_id.should == merchant_account_id
@@ -50,12 +58,9 @@ describe Spree::Gateway::BraintreeGateway do
       it 'should have a preferences[:merchant_account_id]' do
         @gateway.preferences.keys.include?(:merchant_account_id).should be_true
       end
-      
-      it 'should adjust options to include merchant_account_id' do
-        options = {}
-        @gateway.should_receive(:adjust_billing_address).once
-        @gateway.send(:adjust_options_for_braintree, double, options)
-        options['merchant_account_id'].should == merchant_account_id
+
+      it 'should be present in options' do
+        @gateway.options.keys.include?(:merchant_account_id).should be_true
       end
     end
   end


### PR DESCRIPTION
This is a fix for a bug introduced in this commit:

https://github.com/spree/spree_gateway/commit/d58d419050942ec7f9232bf8d8b1d69691eb06a0

The super.provider creates the BraintreeBlueGateway object with all preference hashes so merchant_account_id is always sent, even if blank. This will create a regression where all Braintree transactions receive a 91513 error code.

The fix is to not bother with the adjustment methods and instead extend def options to remove the merchant_account_id if it is blank? then return the hash for super.provider.

I also tried doing this in def preferences, but this logic determines what fields are shown in the admin tool for payment  methods.
