### PR TITLE
Update expiry from Braintree

### DIFF
--- a/spec/models/gateway/braintree_gateway_spec.rb
+++ b/spec/models/gateway/braintree_gateway_spec.rb
@@ -231,11 +231,27 @@ describe Spree::Gateway::BraintreeGateway do
     end
   end
 
-  describe "update_card_number" do
+  describe "update_cc_data" do
+    let(:credit_card) do
+      { 'token' => 'testing', 'last_4' => '1234', 'masked_number' => '5555**5555', 'expiration_date' => '01/2015' }
+    end
+  
+    subject { @gateway.update_cc_data(@payment.source, credit_card) }
+
     it "passes through gateway_payment_profile_id" do
-      credit_card = { 'token' => 'testing', 'last_4' => '1234', 'masked_number' => '5555**5555' }
-      @gateway.update_card_number(@payment.source, credit_card)
+      subject
       @payment.source.gateway_payment_profile_id.should == "testing"
+    end
+
+    it "updates expiry" do
+      subject
+      @payment.source.month.should == '01'
+      @payment.source.year.should == '2015'
+    end
+
+    it "sets encrypted_values to false" do
+      subject
+      @payment.source.encrypted_values.should be_false
     end
   end
 


### PR DESCRIPTION
NOTE: There is 1 new failing test until the corresponding commit in Spree Core is accepted as well.

https://github.com/HoyaBoya/spree_gateway/blob/9bbf1a3b796642b25c1b13677438e73c1a9ad459/spec/models/gateway/braintree_gateway_spec.rb#L252-L255

This allows month/year to be updated from Braintree along with CC last_digits.

If Braintree JS encryption is used per their recommendation....

https://www.braintreepayments.com/docs/javascript/encryption/overview

...then expiry will never be set to the proper unencrypted value in Spree::CreditCard unless we read it from their response like CC number.

need to set encrypted values to false (see spree/spree pull request)
