### PR TITLE
Fix BalancedGateway bug to create profile when active_marchant has chang...

### DIFF
--- a/app/models/spree/gateway/balanced_gateway.rb
+++ b/app/models/spree/gateway/balanced_gateway.rb
@@ -23,14 +23,13 @@ module Spree
       options[:email] = payment.order.email
       options[:login] = preferred_login
 
-      card_uri = provider.store(payment.source, options)
-
+      card_store_response = provider.store(payment.source, options)
+      card_uri = card_store_response.authorization.split(';').first
+      
       # A success just returns a string of the token. A failed request returns a bad request response with a message.
-      if card_uri.is_a?(String)
-        payment.source.update_attributes!(:gateway_payment_profile_id => card_uri)
-      else
-        payment.send(:gateway_error, card_uri.message)
-      end
+      payment.source.update_attributes!(:gateway_payment_profile_id => card_uri)
+    rescue Error => ex
+      payment.send(:gateway_error, ex.message)
     end
 
     def options_with_test_preference


### PR DESCRIPTION
In last version of active_marchant, the function ActiveMerchant::Billing::BalancedGateway.store returns the String as card_uri.
But for newest version, it returns a ActiveMerchant::Billing::Response object, with the authorization attribute (String) which is combined card_uri and account_uri. So it raises error on function Spree::Gateway::BalancedGateway.create_profile.
It is the reason of very popular issue: --- Card stored

it need to fixed to change that "create_profile" function like these commits.
