### PR TITLE
Removed savon dependency

### DIFF
--- a/config/initializers/savon.rb
+++ b/config/initializers/savon.rb
@@ -1,3 +1,0 @@
-# Disable the Savon log so SOAP data (eg. credit-card numbers) will not be captured
-
-Savon.config.log = false

--- a/lib/spree_gateway.rb
+++ b/lib/spree_gateway.rb
@@ -1,4 +1,3 @@
 require 'spree_core'
 require 'spree_gateway/engine'
-require 'savon'
 require 'coffee_script'

--- a/spec/models/savon_spec.rb
+++ b/spec/models/savon_spec.rb
@@ -1,9 +1,0 @@
-require 'spec_helper'
-
-describe Savon do
-  let(:config) { Savon.config }
-
-  it 'does not log anything' do
-    expect(Savon.config.logger).to be_a_kind_of Savon::NullLogger
-  end
-end

--- a/spree_gateway.gemspec
+++ b/spree_gateway.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency 'spree_core', '~> 2.3.0.beta'
-  s.add_dependency 'savon', '~> 1.2'
 
   s.add_development_dependency 'factory_girl', '~> 4.4'
   s.add_development_dependency 'rspec-rails', '~> 2.14'


### PR DESCRIPTION
There are several reasons for this.
- `spree_gateway` does not use `Savon` directly anymore
- it was used to disable savon's logging which is well beyond the responsibility of this extension imho
- the dependency was very strict, `~> 1.2` - a very old version of savon
