### PR TITLE
fix capture in StripeGateway

### DIFF
--- a/app/models/spree/gateway/stripe_gateway.rb
+++ b/app/models/spree/gateway/stripe_gateway.rb
@@ -23,8 +23,8 @@ module Spree
       provider.authorize(*options_for_purchase_or_auth(money, creditcard, gateway_options))
     end
 
-    def capture(payment, creditcard, gateway_options)
-      provider.capture((payment.amount * 100).round, payment.response_code, gateway_options)
+    def capture(money, response_code, gateway_options)
+      provider.capture(money, response_code, gateway_options)
     end
 
     def credit(money, creditcard, response_code, gateway_options)


### PR DESCRIPTION
I found that capturing with Stripe failed in 2-2-stable.

Seems like the interface to capture has changed and is not expecting the payment object to be passed in, and instead the amount in cents and the response code is passed as the parameters.

To prevent changes like this breaking functionality in future, I've created tests that make use of the Payment class. I know this goes beyond unit testing but stubbing is not enough for such an important spec and am willing to incur the potential for slightly brittler tests (should anything in the Payment class change within the capture flow).

I've tested this in test and production using 2-2-stable.
