### PR TITLE
Fixes New Braintree Cancel Method

### DIFF
--- a/app/models/spree/gateway/braintree_gateway.rb
+++ b/app/models/spree/gateway/braintree_gateway.rb
@@ -118,6 +118,7 @@ module Spree
     end
 
     def cancel(response_code)
+      provider
       transaction = ::Braintree::Transaction.find(response_code)
       # From: https://www.braintreepayments.com/docs/ruby/transactions/refund
       # "A transaction can be refunded if its status is settled or settling.


### PR DESCRIPTION
Without calling `provider`, Braintree was not authenticating properly when trying to cancel orders.

Related to https://github.com/spree/spree_gateway/issues/145 and https://github.com/radar/spree/commit/b66036d2c08616ce419c606c43c27056d53f9be5
