### PR TITLE
Change card.type to card.brand to match Stripe API change.

### DIFF
--- a/app/assets/javascripts/store/gateway/stripe.js.coffee
+++ b/app/assets/javascripts/store/gateway/stripe.js.coffee
@@ -44,7 +44,7 @@ stripeResponseHandler = (status, response) ->
   else
     Spree.stripePaymentMethod.find('#card_number, #card_expiry, #card_code').prop("disabled" , true)
     Spree.stripePaymentMethod.find(".ccType").prop("disabled", false)
-    Spree.stripePaymentMethod.find(".ccType").val(mapCC(response.card.type))
+    Spree.stripePaymentMethod.find(".ccType").val(mapCC(response.card.brand))
 
     # token contains id, last4, and card type
     token = response['id'];


### PR DESCRIPTION
The Stripe API had a minor change: https://stripe.com/docs/upgrades .  On 2014-06-13 they renamed card.type to card.brand.
