### PR TITLE
Added a partner string to the payflow gateway.

### DIFF
--- a/app/models/spree/gateway/payflow_pro.rb
+++ b/app/models/spree/gateway/payflow_pro.rb
@@ -2,6 +2,7 @@ module Spree
   class Gateway::PayflowPro < Gateway
     preference :login, :string
     preference :password, :password
+    preference :partner, :string
 
     def provider_class
       ActiveMerchant::Billing::PayflowGateway


### PR DESCRIPTION
Pull request to solve https://github.com/spree/spree_gateway/issues/184

It add a partner string in the payflow pro gateway which is needed outside the US.
