### PR TITLE
Remove unnecessary orders routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Spree::Core::Engine.add_routes do
   # Add your extension routes here
-  resources :orders do
+  resources :orders, :only => [] do
     resource :checkout, :controller => 'checkout' do
       member do
         get :skrill_cancel


### PR DESCRIPTION
The orders resource in spree excludes index, new, create and destroy but the previous code was re-adding these back while trying to define nested resources.

This patch fixes the unnecessary routes from being added by specifying that no order resource routes should be added.
