### PR TITLE
Use credit card tokens over customer profile ids

### DIFF
--- a/app/models/spree/gateway/braintree_gateway.rb
+++ b/app/models/spree/gateway/braintree_gateway.rb
@@ -37,7 +37,14 @@ module Spree
 
     def authorize(money, creditcard, options = {})
       adjust_options_for_braintree(creditcard, options)
-      payment_method = creditcard.gateway_customer_profile_id || creditcard
+
+      if creditcard.gateway_payment_profile_id
+        payment_method = creditcard.gateway_payment_profile_id
+        options[:payment_method_token] = true
+      else
+        payment_method = creditcard.gateway_customer_profile_id || creditcard
+      end
+
       provider.authorize(money, payment_method, options)
     end
 

--- a/spec/models/gateway/braintree_gateway_spec.rb
+++ b/spec/models/gateway/braintree_gateway_spec.rb
@@ -179,6 +179,37 @@ describe Spree::Gateway::BraintreeGateway do
   end
 
   describe 'authorize' do
+    context "the credit card has a token" do
+      before(:each) do
+        @credit_card.update_attributes(gateway_payment_profile_id: 'test')
+      end
+
+      it 'calls provider#authorize using the gateway_payment_profile_id' do
+        expect(@gateway.provider).to receive(:authorize).with(500, 'test', { payment_method_token: true } )
+        @gateway.authorize(500, @credit_card)
+      end
+    end
+
+    context "the given credit card does not have a token" do
+      context "the credit card has a customer profile id" do
+        before(:each) do
+          @credit_card.update_attributes(gateway_customer_profile_id: '12345')
+        end
+
+        it 'calls provider#authorize using the gateway_customer_profile_id' do
+          expect(@gateway.provider).to receive(:authorize).with(500, '12345', {})
+          @gateway.authorize(500, @credit_card)
+        end
+      end
+
+      context "no customer profile id" do
+        it 'calls provider#authorize with the credit card object' do
+          expect(@gateway.provider).to receive(:authorize).with(500, @credit_card, {})
+          @gateway.authorize(500, @credit_card)
+        end
+      end
+    end
+
     it 'return a success response with an authorization code' do
       result = @gateway.authorize(500, @credit_card)
 


### PR DESCRIPTION
In the Braintree gateway, `authorize` passes the customer profile id to Braintree. If the customer has multiple credit cards stored in Braintree, the one that is marked as default in Braintree will be selected regardless of which credit card the user actually selected in Spree.

Passing the credit card's payment token should fix this issue. I still left in the use of the customer profile id as the payment method if the credit card's token doesn't exist, but I think it may be better to just remove the use of that altogether and default to the credit card instance itself if `creditcard.gateway_payment_profile_id` is not present. Any thoughts on this?

I also just want to note that this requires version 1.44 of activemerchant to work. That is when the `payment_method_token` option was introduced. It seems like most versions of Spree are on 1.44.1 now so I think this should be fine.
