### PR TITLE
Trigger javascript submit event instead of calling submit() so other submit handlers can be run,...

### DIFF
--- a/lib/views/frontend/spree/checkout/payment/_stripe.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/_stripe.html.erb
@@ -41,7 +41,7 @@
       Spree.stripePaymentMethod.append("<input type='hidden' class='stripeToken' name='payment_source[" + paymentMethodId + "][last_digits]' value='" + response.card.last4 + "'/>");
       Spree.stripePaymentMethod.append("<input type='hidden' class='stripeToken' name='payment_source[" + paymentMethodId + "][month]' value='" + response.card.exp_month + "'/>");
       Spree.stripePaymentMethod.append("<input type='hidden' class='stripeToken' name='payment_source[" + paymentMethodId + "][year]' value='" + response.card.exp_year + "'/>");
-      return Spree.stripePaymentMethod.parents("form").get(0).submit();
+      return Spree.stripePaymentMethod.parents("form").trigger('submit');
     }
   };
 


### PR DESCRIPTION
... e.g. Spree.disableSaveOnClick()