### PR TITLE
Add CyberSource gateway

### DIFF
--- a/app/models/spree/gateway/cyber_source.rb
+++ b/app/models/spree/gateway/cyber_source.rb
@@ -1,0 +1,10 @@
+module Spree
+  class Gateway::CyberSource < Gateway
+    preference :login, :string
+    preference :password, :password
+
+    def provider_class
+      ActiveMerchant::Billing::CyberSourceGateway
+    end
+  end
+end

--- a/lib/spree_gateway/engine.rb
+++ b/lib/spree_gateway/engine.rb
@@ -32,6 +32,7 @@ module SpreeGateway
         app.config.spree.payment_methods << Spree::Gateway::Maxipago
         app.config.spree.payment_methods << Spree::Gateway::Migs
         app.config.spree.payment_methods << Spree::Gateway::SpreedlyCoreGateway
+        app.config.spree.payment_methods << Spree::Gateway::CyberSource
     end
 
     def self.activate

--- a/spec/models/gateway/cyber_source_spec.rb
+++ b/spec/models/gateway/cyber_source_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Spree::Gateway::CyberSource do
+  let(:gateway) { described_class.create!(name: 'CyberSource') }
+
+  context '.provider_class' do
+    it 'is a CyberSource gateway' do
+      expect(subject.provider_class).to eq ::ActiveMerchant::Billing::CyberSourceGateway
+    end
+  end
+end


### PR DESCRIPTION
Add basic support for the CyberSource gateway, already supported within ActiveMerchant.
