### PR TITLE
Correct Stripe cancel function

### DIFF
--- a/app/models/spree/gateway/stripe_gateway.rb
+++ b/app/models/spree/gateway/stripe_gateway.rb
@@ -41,7 +41,7 @@ module Spree
       provider.void(response_code, {})
     end
     
-    def cancel(response_code, creditcard, gateway_options)
+    def cancel(response_code)
       provider.void(response_code, {})
     end
 


### PR DESCRIPTION
Only receives a single argument