### PR TITLE
Create profile options

### DIFF
--- a/app/models/spree/gateway/authorize_net_cim.rb
+++ b/app/models/spree/gateway/authorize_net_cim.rb
@@ -37,7 +37,7 @@ module Spree
     end
 
     def credit(amount, creditcard, response_code, gateway_options)
-      create_transaction(amount, creditcard, :refund, :trans_id => response_code)
+      create_transaction(amount, creditcard, :refund, { :trans_id => response_code }.merge( transaction_options( gateway_options ) ))
     end
 
     def void(response_code, creditcard, gateway_options)

--- a/app/models/spree/gateway/authorize_net_cim.rb
+++ b/app/models/spree/gateway/authorize_net_cim.rb
@@ -100,6 +100,15 @@ module Spree
           { :customer_profile_id => response.params['customer_profile_id'],
             :customer_payment_profile_id => response.params['customer_payment_profile_id_list'].values.first }
         else
+          if response && response.params['validation_direct_response_list'] && response.params['validation_direct_response_list']['string']
+            r = response.params['validation_direct_response_list']['string'].split(',')
+            if r.present? && r[2].present?
+              rc = r[2].to_i
+              if rc == 65 || rc == 44 || rc == 45
+                response.params['message'] = 'Incorrect security code.'
+              end
+            end
+          end 
           payment.send(:gateway_error, response)
         end
       end

--- a/app/models/spree/gateway/authorize_net_cim.rb
+++ b/app/models/spree/gateway/authorize_net_cim.rb
@@ -111,7 +111,7 @@ module Spree
           info = { :bill_to => generate_address_hash(payment.order.bill_address),
                    :payment => { :credit_card => payment.source } }
         end
-        validation_mode = preferred_validate_on_profile_create ? preferred_server.to_sym : :none
+        validation_mode = preferred_validate_on_profile_create ? :live  : :none
 
         { :profile => { :merchant_customer_id => "#{Time.now.to_f}",
                         #:ship_to_list => generate_address_hash(creditcard.checkout.ship_address),

--- a/app/models/spree/gateway/authorize_net_cim.rb
+++ b/app/models/spree/gateway/authorize_net_cim.rb
@@ -126,6 +126,7 @@ module Spree
       def cim_gateway
         ActiveMerchant::Billing::Base.gateway_mode = preferred_server.to_sym
         gateway_options = options
+        gateway_options[:test_requests] = gateway_options[:test_mode]
         ActiveMerchant::Billing::AuthorizeNetCimGateway.new(gateway_options)
       end
   end

--- a/app/models/spree/gateway/authorize_net_cim.rb
+++ b/app/models/spree/gateway/authorize_net_cim.rb
@@ -25,12 +25,11 @@ module Spree
     end
 
     def authorize(amount, creditcard, gateway_options)
-      t_options = { :order => {:invoice_number => gateway_options[:order_id] } }
-       create_transaction( amount, creditcard, :auth_only, t_options )
+      create_transaction(amount, creditcard, :auth_only, transaction_options(gateway_options))
     end
 
     def purchase(amount, creditcard, gateway_options)
-      create_transaction(amount, creditcard, :auth_capture)
+      create_transaction(amount, creditcard, :auth_capture, transaction_options(gateway_options))
     end
 
     def capture(authorization, creditcard, gateway_options)
@@ -66,6 +65,11 @@ module Spree
     end
 
     private
+
+      def transaction_options(gateway_options)
+        { :order => { :invoice_number => gateway_options[:order_id] } }
+      end
+
       # Create a transaction on a creditcard
       # Set up a CIM profile for the card if one doesn't exist
       # Valid transaction_types are :auth_only, :capture_only and :auth_capture

--- a/app/models/spree/gateway/braintree_gateway.rb
+++ b/app/models/spree/gateway/braintree_gateway.rb
@@ -119,6 +119,7 @@ module Spree
     end
 
     def cancel(response_code)
+      provider
       transaction = ::Braintree::Transaction.find(response_code)
       # From: https://www.braintreepayments.com/docs/ruby/transactions/refund
       # "A transaction can be refunded if its status is settled or settling.

--- a/app/models/spree/gateway/braintree_gateway.rb
+++ b/app/models/spree/gateway/braintree_gateway.rb
@@ -48,7 +48,8 @@ module Spree
 
     def create_profile(payment)
       if payment.source.gateway_customer_profile_id.nil?
-        response = provider.store(payment.source)
+        binding.pry
+        response = provider.store(payment.source, create_profile_options_for_braintree(payment))
         if response.success?
           payment.source.update_attributes!(:gateway_customer_profile_id => response.params['customer_vault_id'])
           cc = response.params['braintree_customer'].fetch('credit_cards',[]).first
@@ -156,6 +157,30 @@ module Spree
 
       def adjust_options_for_braintree(creditcard, options)
         adjust_billing_address(creditcard, options)
+      end
+
+      def create_profile_options_for_braintree(payment, options = {})
+        parameters = options
+        creditcard = payment.source
+        if creditcard.gateway_customer_profile_id
+          parameters[:customer] ||= creditcard.gateway_customer_profile_id
+        end
+        if payment.order && payment.order.user
+          parameters[:email]    ||= payment.order.user.email
+        end
+        if creditcard.bill_address
+          parameters[:billing_address] ||= {
+            :address1     => creditcard.bill_address.address1,
+            :address2     => creditcard.bill_address.address2,
+            :company      => creditcard.bill_address.company,
+            :city         => creditcard.bill_address.city,
+            :state        => creditcard.bill_address.state_text,
+            :zip          => creditcard.bill_address.zipcode,
+            :country      => creditcard.bill_address.country ? creditcard.bill_address.country.iso : nil,
+            :country_name => creditcard.bill_address.country ? creditcard.bill_address.country.name : nil
+          }
+        end
+        parameters
       end
   end
 end


### PR DESCRIPTION
When creating a customer profile on after a payment is created to store the information the Braintree Vault, billing address and email address were not transmitted to the backend.