### PR TITLE
Stripe.js validation errors should decorate fields with "error" class

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Starting point:
 
 * Fork the repo
 * Clone your repo
+* (You will need to `brew install mysql postgres` if you don't already have them installed)
 * Run `bundle`
 * (You may need to `bundle update` if bundler gets stuck)
 * Run `bundle exec rake test_app` to create the test application in `spec/test_app`

--- a/lib/views/frontend/spree/checkout/payment/_stripe.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/_stripe.html.erb
@@ -30,6 +30,15 @@
     var paymentMethodId, token;
     if (response.error) {
       $('#stripeError').html(response.error.message);
+      var param_map = {
+        number:    '#card_number',
+        exp_month: '#card_expiry',
+        exp_year:  '#card_expiry',
+        cvc:       '#card_code'
+      }
+      if (response.error.param)
+        Spree.stripePaymentMethod.find(param_map[response.error.param]).addClass('error');
+
       return $('#stripeError').show();
     } else {
       Spree.stripePaymentMethod.find('#card_number, #card_expiry, #card_code').prop("disabled", true);
@@ -50,6 +59,7 @@
     return $('#checkout_form_payment [data-hook=buttons]').click(function() {
       var expiration, params;
       $('#stripeError').hide();
+      Spree.stripePaymentMethod.find('#card_number, #card_expiry, #card_code').removeClass('error');
       if (Spree.stripePaymentMethod.is(':visible')) {
         expiration = $('.cardExpiry:visible').payment('cardExpiryVal');
         params = $.extend({

--- a/spec/features/stripe_checkout_spec.rb
+++ b/spec/features/stripe_checkout_spec.rb
@@ -62,6 +62,7 @@ describe "Stripe checkout" do
   it "shows an error with an invalid credit card number", :js => true do
     click_button "Save and Continue"
     page.should have_content("This card number looks invalid")
+    page.should have_css('#card_number.error')
   end
 
   it "shows an error with invalid security fields", :js => true do
@@ -69,13 +70,24 @@ describe "Stripe checkout" do
     fill_in "Expiration", :with => "01 / #{Time.now.year + 1}"
     click_button "Save and Continue"
     page.should have_content("Your card's security code is invalid.")
+    page.should have_css('#card_code.error')
   end
 
-  it "shows an error with invalid expiry fields", :js => true do
+  it "shows an error with invalid expiry month field", :js => true do
     fill_in "Card Number", :with => "4242 4242 4242 4242"
     fill_in "Expiration", :with => "00 / #{Time.now.year + 1}"
     fill_in "Card Code", :with => "123"
     click_button "Save and Continue"
     page.should have_content("Your card's expiration month is invalid.")
+    page.should have_css('#card_expiry.error')
+  end
+
+  it "shows an error with invalid expiry year field", :js => true do
+    fill_in "Card Number", :with => "4242 4242 4242 4242"
+    fill_in "Expiration", :with => "12 / "
+    fill_in "Card Code", :with => "123"
+    click_button "Save and Continue"
+    page.should have_content("Your card's expiration year is invalid.")
+    page.should have_css('#card_expiry.error')
   end
 end

--- a/spree_gateway.gemspec
+++ b/spree_gateway.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'launchy'
   s.add_development_dependency 'mysql2'
   s.add_development_dependency 'pg'
-  s.add_development_dependency 'poltergeist', '~> 1.5.0'
+  s.add_development_dependency 'poltergeist', '~> 1.6.0'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rspec-activemodel-mocks'
   s.add_development_dependency 'rspec-rails', '~> 2.99'


### PR DESCRIPTION
I had to upgrade the poltergeist version since current phantomjs (as installed via `brew`) is 2.0
poltergeist 1.5.x requires phantomjs 1.8.x

Also noted in README that mysql and postgres are mandatory dependencies for development.