### PR TITLE
Support Stripe destination options and preference

### DIFF
--- a/app/models/spree/gateway/stripe_gateway.rb
+++ b/app/models/spree/gateway/stripe_gateway.rb
@@ -2,6 +2,7 @@ module Spree
   class Gateway::StripeGateway < Gateway
     preference :secret_key, :string
     preference :publishable_key, :string
+    preference :destination, :string
 
     CARD_TYPE_MAPPING = {
       'American Express' => 'american_express',
@@ -84,6 +85,7 @@ module Spree
       options = {}
       options[:description] = "Spree Order ID: #{gateway_options[:order_id]}"
       options[:currency] = gateway_options[:currency]
+      options[:destination] = preferred_destination if preferred_destination.present?
 
       if customer = creditcard.gateway_customer_profile_id
         options[:customer] = customer

--- a/spec/models/gateway/stripe_gateway_spec.rb
+++ b/spec/models/gateway/stripe_gateway_spec.rb
@@ -29,6 +29,28 @@ describe Spree::Gateway::StripeGateway do
     subject.stub(:provider).and_return provider
   end
 
+  describe '#options_for_purchase_or_auth' do
+    let(:money) { 'foo' }
+    let(:destination) { 'destination' }
+    let(:creditcard) { double(Spree::CreditCard, gateway_customer_profile_id: 1, gateway_payment_profile_id: 2) }
+    let(:gateway_options) { {} }
+
+    before do
+      subject.unstub(:options_for_purchase_or_auth)
+    end
+
+    context 'when destination is set' do
+      before do
+        subject.set_preference :destination, destination
+      end
+
+      it 'should return the destination in options' do
+        results = subject.send(:options_for_purchase_or_auth, money, creditcard, gateway_options)
+        expect(results.last[:destination]).to eq('foo')
+      end
+    end
+  end
+
   describe '#create_profile' do
     before do
       payment.source.stub(:update_attributes!)


### PR DESCRIPTION
This PR supports Stripe Destination on charges.

https://stripe.com/docs/connect/payments-fees#charging-through-the-platform

This feature has been added to ActiveMerchant 1.49, where as Spree is on 1.47, so this is a bit early to introduce until Spree is on a more recent version of AM. However, I would be much indebted for a general direction if this is the right way to expand upon Stripe configurations and options.

https://github.com/activemerchant/active_merchant/commit/dd542883f35d33650cf216e5b773b500b5bbaf26

<img width="753" alt="screen shot 2015-07-23 at 3 30 48 pm" src="https://cloud.githubusercontent.com/assets/134368/8861394/4076227a-3158-11e5-9dae-645c2d21002e.png">

And the error from Stripe when I sent an invalid destination.

```
Gateway Error
  --- !ruby/object:ActiveMerchant::Billing::Response
params:
  error:
    type: invalid_request_error
    message: 'No such merchant: DESTINATION'
    param: destination
message: 'No such merchant: DESTINATION'
success: false
test: false
authorization: 
fraud_review: 
error_code: 
emv_authorization: 
avs_result:
  code: 
  message: 
  street_match: 
  postal_match: 
cvv_result:
  code: 
  message:
```
