### PR TITLE
3-1-stable: fix spec for braintree, bump spree version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'spree', github: 'spree/spree', branch: 'master'
+gem 'spree', github: 'spree/spree', branch: '3-1-stable'
 
 gemspec

--- a/spec/models/gateway/braintree_gateway_spec.rb
+++ b/spec/models/gateway/braintree_gateway_spec.rb
@@ -2,6 +2,9 @@ require 'spec_helper'
 require 'pry'
 
 describe Spree::Gateway::BraintreeGateway do
+  let!(:country) { create(:country, name: 'United States', iso_name: 'UNITED STATES', iso3: 'USA', iso: 'US', numcode: 840) }
+  let!(:state) { create(:state, name: 'Maryland', abbr: 'MD', country: country) }
+  let!(:address) { create(:address, firstname: 'John', lastname: 'Doe', address1: '1234 My Street', address2: 'Apt 1', city: 'Washington DC', zipcode: '20123', phone: '(555)555-5555', state: state, country: country) }
 
   before do
     Spree::Gateway.update_all(active: false)
@@ -15,20 +18,6 @@ describe Spree::Gateway::BraintreeGateway do
     @gateway.save!
 
     with_payment_profiles_off do
-      country = create(:country, name: 'United States', iso_name: 'UNITED STATES', iso3: 'USA', iso: 'US', numcode: 840)
-      state   = create(:state, name: 'Maryland', abbr: 'MD', country: country)
-      address = create(:address,
-        firstname: 'John',
-        lastname:  'Doe',
-        address1:  '1234 My Street',
-        address2:  'Apt 1',
-        city:      'Washington DC',
-        zipcode:   '20123',
-        phone:     '(555)555-5555',
-        state:     state,
-        country:   country
-      )
-
       order = create(:order_with_totals, bill_address: address, ship_address: address)
       order.update!
 
@@ -48,21 +37,6 @@ describe Spree::Gateway::BraintreeGateway do
 
   describe 'payment profile creation' do
     before do
-      country = create(:country, name: 'United States', iso_name: 'UNITED STATES', iso3: 'USA', iso: 'US', numcode: 840)
-      state   = create(:state, name: 'Maryland', abbr: 'MD', country: country)
-      address = create(:address,
-        firstname: 'John',
-        lastname:  'Doe',
-        address1:  '1234 My Street',
-        address2:  'Apt 1',
-        city:      'Washington DC',
-        zipcode:   '20123',
-        phone:     '(555)555-5555',
-        state:     state,
-        country:   country
-      )
-      @address = address
-
       order = create(:order_with_totals, bill_address: address, ship_address: address)
       order.update!
 
@@ -82,12 +56,12 @@ describe Spree::Gateway::BraintreeGateway do
         remote_customer = @gateway.provider.instance_variable_get(:@braintree_gateway).customer.find(@credit_card.gateway_customer_profile_id)
         remote_address = remote_customer.addresses.first rescue nil
         expect(remote_address).not_to be_nil
-        expect(remote_address.street_address).to eq(@address.address1)
-        expect(remote_address.extended_address).to eq(@address.address2)
-        expect(remote_address.locality).to eq(@address.city)
-        expect(remote_address.region).to eq(@address.state.name)
-        expect(remote_address.country_code_alpha2).to eq(@address.country.iso)
-        expect(remote_address.postal_code).to eq(@address.zipcode)
+        expect(remote_address.street_address).to eq(address.address1)
+        expect(remote_address.extended_address).to eq(address.address2)
+        expect(remote_address.locality).to eq(address.city)
+        expect(remote_address.region).to eq(address.state.name)
+        expect(remote_address.country_code_alpha2).to eq(address.country.iso)
+        expect(remote_address.postal_code).to eq(address.zipcode)
       end
     end
 
@@ -95,21 +69,6 @@ describe Spree::Gateway::BraintreeGateway do
 
   describe 'payment profile failure' do
     before do
-      country = create(:country, name: 'United States', iso_name: 'UNITED STATES', iso3: 'USA', iso: 'US', numcode: 840)
-      state   = create(:state, name: 'Maryland', abbr: 'MD', country: country)
-      address = create(:address,
-        firstname: 'John',
-        lastname:  'Doe',
-        address1:  '1234 My Street',
-        address2:  'Apt 1',
-        city:      'Washington DC',
-        zipcode:   '20123',
-        phone:     '(555)555-5555',
-        state:     state,
-        country:   country
-      )
-      @address = address
-
       order = create(:order_with_totals, bill_address: address, ship_address: address)
       order.update!
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require 'rspec/active_model/mocks'
 require 'capybara/rspec'
 require 'capybara/rails'
 require 'capybara/poltergeist'
+require 'capybara-screenshot/rspec'
 require 'database_cleaner'
 require 'ffaker'
 require 'rspec/active_model/mocks'
@@ -19,6 +20,7 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
 require 'spree/testing_support/factories'
 require 'spree/testing_support/order_walkthrough'
 require 'spree/testing_support/preferences'
+require 'spree/testing_support/capybara_ext'
 
 FactoryGirl.find_definitions
 

--- a/spree_gateway.gemspec
+++ b/spree_gateway.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_core', '~> 3.1.0.beta'
 
   s.add_development_dependency 'braintree'
-  s.add_development_dependency 'capybara'
+  s.add_development_dependency 'capybara', '~> 2.5'
+  s.add_development_dependency 'capybara-screenshot', '~> 1.0.11'
   s.add_development_dependency 'coffee-rails', '~> 4.0.0'
   s.add_development_dependency 'database_cleaner', '1.2.0'
   s.add_development_dependency 'factory_girl', '~> 4.4'


### PR DESCRIPTION
- Fix spec for braintree caused by presence validation in country attributes in spree.
- Use spree 3-1-stable branch
- Add capybara-screenshot development dependency.