### PR TITLE
Unify version of sass-rails gem with spree gem

### DIFF
--- a/spec/features/stripe_checkout_spec.rb
+++ b/spec/features/stripe_checkout_spec.rb
@@ -61,7 +61,7 @@ describe "Stripe checkout" do
 
   it "shows an error with an invalid credit card number", :js => true do
     click_button "Save and Continue"
-    page.should have_content("This card number looks invalid")
+    page.should have_content("The card number is not a valid credit card number")
     page.should have_css('#card_number.error')
   end
 

--- a/spree_gateway.gemspec
+++ b/spree_gateway.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rspec-activemodel-mocks'
   s.add_development_dependency 'rspec-rails', '~> 2.99'
-  s.add_development_dependency 'sass-rails', '~> 4.0.2'
+  s.add_development_dependency 'sass-rails', '~> 5.0.0'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'


### PR DESCRIPTION
We can't `bundle install` spree_gateway gem on `3-0-stable` because spree 3-0-satble branch is using `sass-rails ~> 5.0.0`.
The sass gem will be conflict version.

I unified `gemspec` with spree 3-0-stable's sass-rails version.
See https://github.com/spree/spree/blob/3-0-stable/common_spree_dependencies.rb#L7 for reference.