### PR TITLE
Fix spec tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ env:
   - DB=postgres
 language: ruby
 rvm:
-  - 2.1
+  - 2.2.5
 sudo: false

--- a/lib/controllers/frontend/spree/checkout_controller_decorator.rb
+++ b/lib/controllers/frontend/spree/checkout_controller_decorator.rb
@@ -20,7 +20,7 @@ module Spree
 
       until @order.state == "complete"
         if @order.next!
-          @order.update!
+          @order.update_with_updater!
           state_callback(:after)
         end
       end

--- a/spec/features/stripe_checkout_spec.rb
+++ b/spec/features/stripe_checkout_spec.rb
@@ -60,8 +60,10 @@ describe "Stripe checkout" do
   end
 
   it "shows an error with an invalid credit card number", :js => true do
+    # Card number is NOT valid. Fails Luhn checksum
+    fill_in "Card Number", :with => "4242 4242 4242 4249"
     click_button "Save and Continue"
-    page.should have_content("The card number is not a valid credit card number")
+    page.should have_content("Your card number is incorrect")
     page.should have_css('.has-error #card_number.error')
   end
 

--- a/spec/features/stripe_checkout_spec.rb
+++ b/spec/features/stripe_checkout_spec.rb
@@ -24,7 +24,7 @@ describe "Stripe checkout" do
 
     order.reload
     order.user = user
-    order.update!
+    order.update_with_updater!
 
     Spree::CheckoutController.any_instance.stub(:current_order => order)
     Spree::CheckoutController.any_instance.stub(:try_spree_current_user => user)

--- a/spec/models/gateway/braintree_gateway_spec.rb
+++ b/spec/models/gateway/braintree_gateway_spec.rb
@@ -19,7 +19,7 @@ describe Spree::Gateway::BraintreeGateway do
 
     with_payment_profiles_off do
       order = create(:order_with_totals, bill_address: address, ship_address: address)
-      order.update!
+      order.update_with_updater!
 
       # Use a valid CC from braintree sandbox: https://www.braintreepayments.com/docs/ruby/reference/sandbox
 
@@ -38,7 +38,7 @@ describe Spree::Gateway::BraintreeGateway do
   describe 'payment profile creation' do
     before do
       order = create(:order_with_totals, bill_address: address, ship_address: address)
-      order.update!
+      order.update_with_updater!
 
       @credit_card = create(:credit_card,
         verification_value: '123',
@@ -70,7 +70,7 @@ describe Spree::Gateway::BraintreeGateway do
   describe 'payment profile failure' do
     before do
       order = create(:order_with_totals, bill_address: address, ship_address: address)
-      order.update!
+      order.update_with_updater!
 
       @credit_card = create(:credit_card,
         verification_value: '123',

--- a/spec/models/gateway/braintree_gateway_spec.rb
+++ b/spec/models/gateway/braintree_gateway_spec.rb
@@ -171,7 +171,7 @@ describe Spree::Gateway::BraintreeGateway do
       result = @gateway.authorize(500, @credit_card)
 
       expect(result.success?).to be true
-      expect(result.authorization).to match /\A\w{6}\z/
+      expect(result.authorization).to match /\A\w{6,}\z/
       expect(Braintree::Transaction::Status::Authorized).to eq Braintree::Transaction.find(result.authorization).status
     end
 
@@ -182,10 +182,10 @@ describe Spree::Gateway::BraintreeGateway do
 
         @payment.process!
         expect(@payment.log_entries.size).to eq(1)
-        expect(@payment.response_code).to match /\A\w{6}\z/
+        expect(@payment.transaction_id).to match /\A\w{6,}\z/
         expect(@payment.state).to eq 'pending'
 
-        transaction = ::Braintree::Transaction.find(@payment.response_code)
+        transaction = ::Braintree::Transaction.find(@payment.transaction_id)
         expect(transaction.status).to eq Braintree::Transaction::Status::Authorized
 
         card_number = @credit_card.number[0..5] + '******' + @credit_card.number[-4..-1]
@@ -252,15 +252,15 @@ describe Spree::Gateway::BraintreeGateway do
     it 'do capture a previous authorization' do
       @payment.process!
       expect(@payment.log_entries.size).to eq(1)
-      expect(@payment.response_code).to match /\A\w{6}\z/
+      expect(@payment.transaction_id).to match /\A\w{6,}\z/
 
-      transaction = ::Braintree::Transaction.find(@payment.response_code)
+      transaction = ::Braintree::Transaction.find(@payment.transaction_id)
       expect(transaction.status).to eq Braintree::Transaction::Status::Authorized
 
-      capture_result = @gateway.capture(@payment.amount, @payment.response_code)
+      capture_result = @gateway.capture(@payment.amount, @payment.transaction_id)
       expect(capture_result.success?).to be true
 
-      transaction = ::Braintree::Transaction.find(@payment.response_code)
+      transaction = ::Braintree::Transaction.find(@payment.transaction_id)
       expect(transaction.status).to eq Braintree::Transaction::Status::SubmittedForSettlement
     end
 
@@ -271,11 +271,11 @@ describe Spree::Gateway::BraintreeGateway do
       @payment.process!
       expect(@payment.log_entries.size).to eq(1)
 
-      transaction = ::Braintree::Transaction.find(@payment.response_code)
+      transaction = ::Braintree::Transaction.find(@payment.transaction_id)
       expect(transaction.status).to eq Braintree::Transaction::Status::Authorized
 
       @payment.capture! # as done in PaymentsController#fire
-      transaction = ::Braintree::Transaction.find(@payment.response_code)
+      transaction = ::Braintree::Transaction.find(@payment.transaction_id)
       expect(transaction.status).to eq Braintree::Transaction::Status::SubmittedForSettlement
       expect(@payment.completed?).to be true
     end
@@ -285,20 +285,20 @@ describe Spree::Gateway::BraintreeGateway do
     it 'return a success response with an authorization code' do
       result =  @gateway.purchase(500, @credit_card)
       expect(result.success?).to be true
-      expect(result.authorization).to match /\A\w{6}\z/
+      expect(result.authorization).to match /\A\w{6,}\z/
       expect(Braintree::Transaction::Status::SubmittedForSettlement).to eq Braintree::Transaction.find(result.authorization).status
     end
 
     it 'work through the spree payment interface with payment profiles' do
       purchase_using_spree_interface
-      transaction = ::Braintree::Transaction.find(@payment.response_code)
+      transaction = ::Braintree::Transaction.find(@payment.transaction_id)
       expect(transaction.credit_card_details.token).not_to be_nil
     end
 
     it 'work through the spree payment interface without payment profiles' do
       with_payment_profiles_off do
         purchase_using_spree_interface(false)
-        transaction = ::Braintree::Transaction.find(@payment.response_code)
+        transaction = ::Braintree::Transaction.find(@payment.transaction_id)
         expect(transaction.credit_card_details.token).to be_nil
       end
     end
@@ -323,9 +323,9 @@ describe Spree::Gateway::BraintreeGateway do
       @payment.process!
 
       expect(@payment.log_entries.size).to eq(1)
-      expect(@payment.response_code).to match /\A\w{6}\z/
+      expect(@payment.transaction_id).to match /\A\w{6,}\z/
 
-      transaction = Braintree::Transaction.find(@payment.response_code)
+      transaction = Braintree::Transaction.find(@payment.transaction_id)
       expect(transaction.status).to eq Braintree::Transaction::Status::SubmittedForSettlement
 
       @payment.void_transaction!
@@ -349,9 +349,9 @@ describe Spree::Gateway::BraintreeGateway do
 
     # Let's get the payment record associated with the credit
     @payment = @order.payments.last
-    expect(@payment.response_code).to match /\A\w{6}\z/
+    expect(@payment.transaction_id).to match /\A\w{6,}\z/
 
-    transaction = ::Braintree::Transaction.find(@payment.response_code)
+    transaction = ::Braintree::Transaction.find(@payment.transaction_id)
     expect(transaction.type).to eq Braintree::Transaction::Type::Credit
     expect(transaction.status).to eq Braintree::Transaction::Status::SubmittedForSettlement
     expect(transaction.credit_card_details.masked_number).to eq '555555******4444'
@@ -366,10 +366,10 @@ describe Spree::Gateway::BraintreeGateway do
     @payment.log_entries.size == 0
     @payment.process! # as done in PaymentsController#create
     @payment.log_entries.size == 1
-    expect(@payment.response_code).to match /\A\w{6}\z/
+    expect(@payment.transaction_id).to match /\A\w{6,}\z/
     expect(@payment.state).to eq 'completed'
 
-    transaction = ::Braintree::Transaction.find(@payment.response_code)
+    transaction = ::Braintree::Transaction.find(@payment.transaction_id)
     expect(Braintree::Transaction::Status::SubmittedForSettlement).to eq transaction.status
     expect(transaction.credit_card_details.masked_number).to eq '555555******4444'
     expect(transaction.credit_card_details.expiration_date).to eq "09/#{Time.now.year + 1}"

--- a/spec/models/gateway/pin_gateway_spec.rb
+++ b/spec/models/gateway/pin_gateway_spec.rb
@@ -23,7 +23,7 @@ describe Spree::Gateway::PinGateway do
     )
 
     order = create(:order_with_totals, bill_address: address, ship_address: address)
-    order.update!
+    order.update_with_updater!
 
     credit_card = create(:credit_card,
       verification_value: '123',

--- a/spec/models/gateway/usa_epay_transaction_spec.rb
+++ b/spec/models/gateway/usa_epay_transaction_spec.rb
@@ -21,7 +21,7 @@ describe Spree::Gateway::UsaEpayTransaction do
       country:   country)
 
     order = create(:order_with_totals, bill_address: address, ship_address: address)
-    order.update!
+    order.update_with_updater!
 
     credit_card = create(:credit_card,
       verification_value: '123',


### PR DESCRIPTION
* Ruby 2.2.5 is required for tests to pass. Updated TravisCI configuration
* Order#update! is no longer valid. Need to use Order#update_with_updater!
* The Braintree tests were failing because of an assumption that response_code (Transaction ID) would always be 6 characters. They're 8 these days and will probably keep growing...
* A Stripe test failed for not sending any card data at all and having an outdated expected error message from the gateway
