### PR TITLE
Add support for the QuickPay gateway

### DIFF
--- a/app/models/spree/gateway/quickpay.rb
+++ b/app/models/spree/gateway/quickpay.rb
@@ -1,0 +1,9 @@
+module Spree
+  class Gateway::Quickpay < Gateway
+    preference :api_key, :string
+
+    def provider_class
+      ActiveMerchant::Billing::QuickpayV10Gateway
+    end
+  end
+end

--- a/lib/spree_gateway/engine.rb
+++ b/lib/spree_gateway/engine.rb
@@ -25,6 +25,7 @@ module SpreeGateway
       app.config.spree.payment_methods << Spree::Gateway::PayflowPro
       app.config.spree.payment_methods << Spree::Gateway::Paymill
       app.config.spree.payment_methods << Spree::Gateway::PinGateway
+      app.config.spree.payment_methods << Spree::Gateway::Quickpay
       app.config.spree.payment_methods << Spree::Gateway::SagePay
       app.config.spree.payment_methods << Spree::Gateway::SecurePayAU
       app.config.spree.payment_methods << Spree::Gateway::SpreedlyCoreGateway

--- a/spec/models/gateway/quickpay_spec.rb
+++ b/spec/models/gateway/quickpay_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Spree::Gateway::Quickpay do
+  let(:gateway) { described_class.create!(name: 'QuickpayGateway') }
+
+  context '.provider_class' do
+    it 'is a Quickpay gateway' do
+      expect(gateway.provider_class).to eq ::ActiveMerchant::Billing::QuickpayV10Gateway
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,7 @@ require 'database_cleaner'
 require 'ffaker'
 require 'rspec/active_model/mocks'
 
-Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
+Dir[File.join(File.dirname(__FILE__), "support", "**", "*.rb")].each { |f| require f }
 
 require 'spree/testing_support/factories'
 require 'spree/testing_support/order_walkthrough'

--- a/spec/support/wait_for_stripe.rb
+++ b/spec/support/wait_for_stripe.rb
@@ -1,0 +1,27 @@
+module WaitForStripe
+  def wait_for_stripe
+    Timeout.timeout(Capybara.default_max_wait_time) do
+      loop until page.evaluate_script('window.activeStripeRequests').zero?
+    end
+  end
+
+  def setup_stripe_watcher
+    page.evaluate_script <<-JS
+      window.activeStripeRequests = 0;
+      $('#checkout_form_payment [data-hook=buttons]').on('click', function() {
+        window.activeStripeRequests = window.activeStripeRequests + 1;
+      });
+      stripeResponseHandler = (function() {
+        var _f = stripeResponseHandler;
+        return function() {
+          window.activeStripeRequests = window.activeStripeRequests - 1;
+          _f.apply(this, arguments);
+        }
+      })();
+    JS
+  end
+end
+
+RSpec.configure do |config|
+  config.include WaitForStripe, type: :feature
+end


### PR DESCRIPTION
Uses v10 of the QuickPay API which requires at least version 1.50 of ActiveMerchant. Ideally 1.59 or greater.

Also fix some tests that can break on slow connections.