### PR TITLE
Integrate Apple Pay using Stipe

### DIFF
--- a/app/models/spree/gateway/stripe_gateway/apple_pay_gateway.rb
+++ b/app/models/spree/gateway/stripe_gateway/apple_pay_gateway.rb
@@ -1,0 +1,7 @@
+module Spree
+  class Gateway::StripeGateway::ApplePayGateway < Gateway::StripeGateway
+    def method_type
+      'applepay'
+    end
+  end
+end

--- a/lib/assets/javascripts/spree/frontend/applepay.js
+++ b/lib/assets/javascripts/spree/frontend/applepay.js
@@ -1,0 +1,82 @@
+var ApplePay = function ($applePay) {
+  this.order_price = $applePay.data('price');
+  this.publishable_key = $applePay.data('publishable-key');
+  this.payment_method_id = $applePay.data('payment-method-id');
+  this.payment_method_name = $applePay.data('payment-method-name');
+  this.currencyCode = $applePay.data('currency');
+  this.countryCode = $applePay.data('country');
+
+  this.mapCC = { 'MasterCard': 'mastercard',
+                 'Visa': 'visa',
+                 'American Express': 'amex',
+                 'Discover': 'discover',
+                 'Diners Club': 'dinersclub',
+                 'JCB': 'jcb'
+              };
+};
+
+ApplePay.prototype.init = function () {
+  this.checkAvailability();
+  this.bindEvents();
+};
+
+ApplePay.prototype.checkAvailability =  function () {
+  var _this = this;
+  Stripe.setPublishableKey(this.publishable_key);
+  Stripe.applePay.checkAvailability(function(){
+    _this.toggleButton();
+  });
+};
+
+ApplePay.prototype.bindEvents = function () {
+  var _this = this;
+  $('#apple-pay-button').on('click', function(){
+    _this.startPaymentRequest();
+  });
+};
+
+ApplePay.prototype.toggleButton = function (available) {
+  if (available) {
+    $('#apple-pay-button').show();
+  } else {
+    var $label = $('#payment-method-fields').find($("label:contains(" + this.payment_method_name + ")"));
+    $label.hide();
+    $label.find($("input[type=radio]")).attr('disabled', true);
+  }
+};
+
+ApplePay.prototype.handleStripeResponse = function (result, completion) {
+  Spree.applePaymentMethod.find('#card_number, #card_expiry, #card_code, .ccType').prop("disabled", true);
+  var token = result['token'];
+  var paymentMethodId = Spree.applePaymentMethod.prop('id').split("_")[2];
+  Spree.applePaymentMethod.append("<input type='hidden' class='ccType' name='payment_source[" + paymentMethodId + "][cc_type]' value='" + this.mapCC[token.card.brand] + "'/>");
+  Spree.applePaymentMethod.append("<input type='hidden' class='stripeToken' name='payment_source[" + paymentMethodId + "][gateway_payment_profile_id]' value='" + token.id + "'/>");
+  Spree.applePaymentMethod.append("<input type='hidden' class='stripeToken' name='payment_source[" + paymentMethodId + "][last_digits]' value='" + token.card.last4 + "'/>");
+  Spree.applePaymentMethod.append("<input type='hidden' class='stripeToken' name='payment_source[" + paymentMethodId + "][month]' value='" + token.card.exp_month + "'/>");
+  Spree.applePaymentMethod.append("<input type='hidden' class='stripeToken' name='payment_source[" + paymentMethodId + "][year]' value='" + token.card.exp_year + "'/>");
+  return Spree.applePaymentMethod.parents("form").get(0).submit();
+};
+
+ApplePay.prototype.startPaymentRequest = function () {
+  this.paymentRequest = {
+    countryCode: this.countryCode,
+    currencyCode: this.currencyCode,
+    total: {
+      label: 'Stripe.com',
+      amount: this.order_price
+    }
+  };
+  this.startSession();
+};
+
+ApplePay.prototype.startSession = function () {
+  var _this = this;
+  Spree.applePaymentMethod = $('#payment_method_' + this.payment_method_id);
+  var session = Stripe.applePay.buildSession(this.paymentRequest,
+    function(result, completion) {
+      _this.handleStripeResponse(result, completion);
+  }, function(error) {
+    console.log(error.message);
+  });
+  session.begin();
+};

--- a/lib/assets/stylesheets/spree/frontend/applepay.css
+++ b/lib/assets/stylesheets/spree/frontend/applepay.css
@@ -1,0 +1,18 @@
+#apple-pay-button {
+  display: block;
+  background-color: black;
+  background-image: -webkit-named-image(apple-pay-logo-white);
+  background-size: 100% 100%;
+  background-origin: content-box;
+  background-repeat: no-repeat;
+  width: 100%;
+  max-width: 150px;
+  height: 20px;
+  padding: 8px 0;
+  border-radius: 4px;
+}
+@media screen and (max-width: 767px) {
+  #apple-pay-button {
+    margin: 0 auto;
+  }
+}

--- a/lib/spree_gateway/engine.rb
+++ b/lib/spree_gateway/engine.rb
@@ -32,13 +32,16 @@ module SpreeGateway
         app.config.spree.payment_methods << Spree::Gateway::Maxipago
         app.config.spree.payment_methods << Spree::Gateway::Migs
         app.config.spree.payment_methods << Spree::Gateway::SpreedlyCoreGateway
+        app.config.spree.payment_methods << Spree::Gateway::StripeGateway::ApplePayGateway
     end
 
     def self.activate
       if SpreeGateway::Engine.frontend_available?
         Rails.application.config.assets.precompile += [
           'lib/assets/javascripts/spree/frontend/spree_gateway.js',
-          'lib/assets/javascripts/spree/frontend/spree_gateway.css',
+          'spree/frontend/applepay.js',
+          'lib/assets/stylesheets/spree/frontend/spree_gateway.css',
+          'spree/frontend/applepay.css',
         ]
         Dir.glob(File.join(File.dirname(__FILE__), "../../controllers/frontend/*/*_decorator*.rb")) do |c|
           Rails.configuration.cache_classes ? require(c) : load(c)

--- a/lib/views/backend/spree/admin/payments/source_views/_applepay.html.erb
+++ b/lib/views/backend/spree/admin/payments/source_views/_applepay.html.erb
@@ -1,0 +1,1 @@
+<%= render "spree/admin/payments/source_views/gateway", payment: payment %>

--- a/lib/views/frontend/spree/checkout/payment/_applepay.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/_applepay.html.erb
@@ -1,0 +1,20 @@
+<%= stylesheet_link_tag "spree/frontend/applepay", media: "all" %>
+<%= javascript_include_tag 'spree/frontend/applepay' %>
+
+<span id="apple-pay-button" class='hide'></span>
+
+<span class='hide' data-hook='applepay-configuration' data-price=<%= @order.total %> data-payment-method-id=<%= payment_method.id %> data-payment-method-name=<%= payment_method.name %> data-publishable-key=<%= payment_method.preferred_publishable_key %> data-currency=<%= @order.currency %> data-country=<%= @order.bill_address.country.iso %>></span>
+
+<script type="text/javascript">
+
+  var applePay = new ApplePay($('[data-hook=applepay-configuration]'));
+
+  if (typeof Stripe === 'undefined') {
+    $.getScript('https://js.stripe.com/v2/', function(){
+      applePay.init();
+    });
+  } else {
+    applePay.init();
+  };
+
+</script>

--- a/spec/models/gateway/stripe_gateway/apple_pay_gateway_spec.rb
+++ b/spec/models/gateway/stripe_gateway/apple_pay_gateway_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Spree::Gateway::StripeGateway::ApplePayGateway do
+  let(:gateway) { Spree::Gateway::StripeGateway::ApplePayGateway.new }
+
+  describe 'inheritance' do
+    it 'is expected to inherit from class StripeGateway' do
+      expect(described_class).to be < Spree::Gateway::StripeGateway
+    end
+  end
+
+  describe '#method_type' do
+    it 'is expected to return applepay' do
+      expect(gateway.method_type).to eq('applepay')
+    end
+  end
+end


### PR DESCRIPTION
1. Create Payment Method for ApplePay, inherited from Stripe.
2. Add JS/CSS for ApplePay.
3. Fix Assets precompile path.
4. Add RSpecs.