### PR TITLE
Add Apple Pay for 3-0-stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ env:
   - DB=postgres
 language: ruby
 rvm:
-  - 2.1
+  - 2.2.5
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ before_script:
   - bundle exec rake test_app
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
+  - sudo apt-get -y install ca-certificates
 env:
   - DB=mysql
   - DB=postgres
 language: ruby
 rvm:
   - 2.2.5
-sudo: false

--- a/app/models/spree/gateway/stripe_gateway/apple_pay_gateway.rb
+++ b/app/models/spree/gateway/stripe_gateway/apple_pay_gateway.rb
@@ -1,0 +1,7 @@
+module Spree
+  class Gateway::StripeGateway::ApplePayGateway < Gateway::StripeGateway
+    def method_type
+      'applepay'
+    end
+  end
+end

--- a/lib/assets/javascripts/spree/frontend/applepay.js
+++ b/lib/assets/javascripts/spree/frontend/applepay.js
@@ -1,0 +1,80 @@
+var ApplePay = function ($applePay) {
+  this.order_price = $applePay.data('price');
+  this.publishable_key = $applePay.data('publishable-key');
+  this.payment_method_id = $applePay.data('payment-method-id');
+  this.payment_method_name = $applePay.data('payment-method-name');
+  this.currencyCode = $applePay.data('currency');
+  this.countryCode = $applePay.data('country');
+
+  this.mapCC = { 'MasterCard': 'mastercard',
+                 'Visa': 'visa',
+                 'American Express': 'amex',
+                 'Discover': 'discover',
+                 'Diners Club': 'dinersclub',
+                 'JCB': 'jcb'
+              };
+};
+
+ApplePay.prototype.init = function () {
+  this.checkAvailability();
+  this.bindEvents();
+};
+
+ApplePay.prototype.checkAvailability =  function () {
+  var _this = this;
+  Stripe.setPublishableKey(this.publishable_key);
+  Stripe.applePay.checkAvailability(this.toggleButton);
+};
+
+ApplePay.prototype.bindEvents = function () {
+  var _this = this;
+  $('#apple-pay-button').on('click', function(){
+    _this.startPaymentRequest();
+  });
+};
+
+ApplePay.prototype.toggleButton = function (available) {
+  if (available) {
+    $('#apple-pay-button').removeClass('hide');
+  } else {
+    var $label = $('#payment-method-fields').find($("label:contains(" + this.payment_method_name + ")"));
+    $label.parents('li').hide();
+    $label.find($("input[type=radio]")).attr('disabled', true);
+  }
+};
+
+ApplePay.prototype.handleStripeResponse = function (result, completion) {
+  Spree.applePaymentMethod.find('#card_number, #card_expiry, #card_code, .ccType').prop("disabled", true);
+  var token = result['token'];
+  var paymentMethodId = Spree.applePaymentMethod.prop('id').split("_")[2];
+  Spree.applePaymentMethod.append("<input type='hidden' class='ccType' name='payment_source[" + paymentMethodId + "][cc_type]' value='" + this.mapCC[token.card.brand] + "'/>");
+  Spree.applePaymentMethod.append("<input type='hidden' class='stripeToken' name='payment_source[" + paymentMethodId + "][gateway_payment_profile_id]' value='" + token.id + "'/>");
+  Spree.applePaymentMethod.append("<input type='hidden' class='stripeToken' name='payment_source[" + paymentMethodId + "][last_digits]' value='" + token.card.last4 + "'/>");
+  Spree.applePaymentMethod.append("<input type='hidden' class='stripeToken' name='payment_source[" + paymentMethodId + "][month]' value='" + token.card.exp_month + "'/>");
+  Spree.applePaymentMethod.append("<input type='hidden' class='stripeToken' name='payment_source[" + paymentMethodId + "][year]' value='" + token.card.exp_year + "'/>");
+  return Spree.applePaymentMethod.parents("form").get(0).submit();
+};
+
+ApplePay.prototype.startPaymentRequest = function () {
+  this.paymentRequest = {
+    countryCode: this.countryCode,
+    currencyCode: this.currencyCode,
+    total: {
+      label: 'Stripe.com',
+      amount: this.order_price
+    }
+  };
+  this.startSession();
+};
+
+ApplePay.prototype.startSession = function () {
+  var _this = this;
+  Spree.applePaymentMethod = $('#payment_method_' + this.payment_method_id);
+  var session = Stripe.applePay.buildSession(this.paymentRequest,
+    function(result, completion) {
+      _this.handleStripeResponse(result, completion);
+  }, function(error) {
+    console.log(error.message);
+  });
+  session.begin();
+};

--- a/lib/assets/stylesheets/spree/frontend/applepay.css
+++ b/lib/assets/stylesheets/spree/frontend/applepay.css
@@ -1,0 +1,18 @@
+#apple-pay-button {
+  display: block;
+  background-color: black;
+  background-image: -webkit-named-image(apple-pay-logo-white);
+  background-size: 100% 100%;
+  background-origin: content-box;
+  background-repeat: no-repeat;
+  width: 100%;
+  max-width: 150px;
+  height: 20px;
+  padding: 8px 0;
+  border-radius: 4px;
+}
+@media screen and (max-width: 767px) {
+  #apple-pay-button {
+    margin: 0 auto;
+  }
+}

--- a/lib/spree_gateway/engine.rb
+++ b/lib/spree_gateway/engine.rb
@@ -30,13 +30,16 @@ module SpreeGateway
       app.config.spree.payment_methods << Spree::Gateway::StripeGateway
       app.config.spree.payment_methods << Spree::Gateway::UsaEpayTransaction
       app.config.spree.payment_methods << Spree::Gateway::Worldpay
+      app.config.spree.payment_methods << Spree::Gateway::StripeGateway::ApplePayGateway
     end
 
     def self.activate
       if SpreeGateway::Engine.frontend_available?
         Rails.application.config.assets.precompile += [
           'lib/assets/javascripts/spree/frontend/spree_gateway.js',
-          'lib/assets/javascripts/spree/frontend/spree_gateway.css',
+          'lib/assets/stylesheets/spree/frontend/spree_gateway.css',
+          'spree/frontend/applepay.js',
+          'spree/frontend/applepay.css',
         ]
         Dir.glob(File.join(File.dirname(__FILE__), "../../controllers/frontend/*/*_decorator*.rb")) do |c|
           Rails.configuration.cache_classes ? require(c) : load(c)

--- a/lib/views/backend/spree/admin/payments/source_views/_applepay.html.erb
+++ b/lib/views/backend/spree/admin/payments/source_views/_applepay.html.erb
@@ -1,0 +1,2 @@
+<%= render "spree/admin/payments/source_views/gateway", payment: payment %>
+

--- a/lib/views/frontend/spree/checkout/payment/_applepay.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/_applepay.html.erb
@@ -1,0 +1,20 @@
+<%= stylesheet_link_tag "spree/frontend/applepay", media: "all" %>
+<%= javascript_include_tag 'spree/frontend/applepay' %>
+
+<span id="apple-pay-button" class='hide'></span>
+
+<span class='hide' data-hook='applepay-configuration' data-price=<%= @order.total %> data-payment-method-id=<%= payment_method.id %> data-payment-method-name=<%= payment_method.name %> data-publishable-key=<%= payment_method.preferred_publishable_key %> data-currency=<%= @order.currency %> data-country=<%= @order.bill_address.country.iso %>></span>
+
+<script type="text/javascript">
+
+  var applePay = new ApplePay($('[data-hook=applepay-configuration]'));
+
+  if (typeof Stripe === 'undefined') {
+    $.getScript('https://js.stripe.com/v2/', function(){
+      applePay.init();
+    });
+  } else {
+    applePay.init();
+  };
+
+</script>

--- a/spec/features/stripe_checkout_spec.rb
+++ b/spec/features/stripe_checkout_spec.rb
@@ -20,15 +20,15 @@ describe "Stripe checkout" do
     user = create(:user)
 
     order = OrderWalkthrough.up_to(:delivery)
-    order.stub :confirmation_required? => true
+    allow(order).to receive_messages :confirmation_required? => true
 
     order.reload
     order.user = user
     order.update!
 
-    Spree::CheckoutController.any_instance.stub(:current_order => order)
-    Spree::CheckoutController.any_instance.stub(:try_spree_current_user => user)
-    Spree::CheckoutController.any_instance.stub(:skip_state_validation? => true)
+    allow_any_instance_of(Spree::CheckoutController).to receive_messages(:current_order => order)
+    allow_any_instance_of(Spree::CheckoutController).to receive_messages(:try_spree_current_user => user)
+    allow_any_instance_of(Spree::CheckoutController).to receive_messages(:skip_state_validation? => true)
 
     visit spree.checkout_state_path(:payment)
   end
@@ -39,9 +39,9 @@ describe "Stripe checkout" do
     fill_in "Card Code", :with => "123"
     fill_in "Expiration", :with => "01 / #{Time.now.year + 1}"
     click_button "Save and Continue"
-    page.current_url.should include("/checkout/confirm")
+    expect(page.current_url).to include("/checkout/confirm")
     click_button "Place Order"
-    page.should have_content("Your order has been processed successfully")
+    expect(page).to have_content("Your order has been processed successfully")
   end
 
   # This will fetch a token from Stripe.com and then pass that to the webserver.
@@ -54,23 +54,31 @@ describe "Stripe checkout" do
     fill_in "Expiration", :with => "01 / #{Time.now.year + 1}"
     click_button "Save and Continue"
     sleep(5) # Wait for Stripe API to return + form to submit
-    page.current_url.should include("/checkout/confirm")
+    expect(page.current_url).to include("/checkout/confirm")
     click_button "Place Order"
-    page.should have_content("Your order has been processed successfully")
+    expect(page).to have_content("Your order has been processed successfully")
   end
 
   it "shows an error with an invalid credit card number", :js => true do
+    fill_in "Card Number", :with => "4242 4242 4242 4243"
+    page.execute_script("$('.cardNumber').trigger('change')")
+    fill_in "Card Code", :with => "123"
+    fill_in "Expiration", :with => "01 / #{Time.now.year + 1}"
     click_button "Save and Continue"
-    page.should have_content("The card number is not a valid credit card number")
-    page.should have_css('#card_number.error')
+    sleep(5) # Wait for Stripe API to return + form to submit
+    click_button "Save and Continue"
+    expect(page).to have_content("Your card number is incorrect")
+    expect(page).to have_css('#card_number.error')
   end
 
   it "shows an error with invalid security fields", :js => true do
     fill_in "Card Number", :with => "4242 4242 4242 4242"
+    page.execute_script("$('.cardNumber').trigger('change')")
+    fill_in "Card Code", :with => "12x"
     fill_in "Expiration", :with => "01 / #{Time.now.year + 1}"
     click_button "Save and Continue"
-    page.should have_content("Your card's security code is invalid.")
-    page.should have_css('#card_code.error')
+    expect(page).to have_content("Your card's security code is invalid.")
+    expect(page).to have_css('#card_code.error')
   end
 
   it "shows an error with invalid expiry month field", :js => true do
@@ -78,8 +86,8 @@ describe "Stripe checkout" do
     fill_in "Expiration", :with => "00 / #{Time.now.year + 1}"
     fill_in "Card Code", :with => "123"
     click_button "Save and Continue"
-    page.should have_content("Your card's expiration month is invalid.")
-    page.should have_css('#card_expiry.error')
+    expect(page).to have_content("Your card's expiration month is invalid.")
+    expect(page).to have_css('#card_expiry.error')
   end
 
   it "shows an error with invalid expiry year field", :js => true do
@@ -87,7 +95,7 @@ describe "Stripe checkout" do
     fill_in "Expiration", :with => "12 / "
     fill_in "Card Code", :with => "123"
     click_button "Save and Continue"
-    page.should have_content("Your card's expiration year is invalid.")
-    page.should have_css('#card_expiry.error')
+    expect(page).to have_content("Your card's expiration year is invalid.")
+    expect(page).to have_css('#card_expiry.error')
   end
 end

--- a/spec/models/gateway/apple_pay_gateway_spec.rb
+++ b/spec/models/gateway/apple_pay_gateway_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Spree::Gateway::StripeGateway::ApplePayGateway do
+  let(:gateway) { Spree::Gateway::StripeGateway::ApplePayGateway.new }
+
+  describe 'inheritance' do
+    it 'is expected to inherit from class StripeGateway' do
+      expect(described_class).to be < Spree::Gateway::StripeGateway
+    end
+  end
+
+  describe '#method_type' do
+    it 'is expected to return applepay' do
+      expect(gateway.method_type).to eq('applepay')
+    end
+  end
+end

--- a/spec/models/gateway/braintree_gateway_spec.rb
+++ b/spec/models/gateway/braintree_gateway_spec.rb
@@ -212,7 +212,7 @@ describe Spree::Gateway::BraintreeGateway do
       result = @gateway.authorize(500, @credit_card)
 
       expect(result.success?).to be true
-      expect(result.authorization).to match /\A\w{6}\z/
+      expect(result.authorization).to match /\A\w{8}\z/
       expect(Braintree::Transaction::Status::Authorized).to eq Braintree::Transaction.find(result.authorization).status
     end
 
@@ -223,7 +223,7 @@ describe Spree::Gateway::BraintreeGateway do
 
         @payment.process!
         expect(@payment.log_entries.size).to eq(1)
-        expect(@payment.response_code).to match /\A\w{6}\z/
+        expect(@payment.response_code).to match /\A\w{8}\z/
         expect(@payment.state).to eq 'pending'
 
         transaction = ::Braintree::Transaction.find(@payment.response_code)
@@ -293,7 +293,7 @@ describe Spree::Gateway::BraintreeGateway do
     it 'do capture a previous authorization' do
       @payment.process!
       expect(@payment.log_entries.size).to eq(1)
-      expect(@payment.response_code).to match /\A\w{6}\z/
+      expect(@payment.response_code).to match /\A\w{8}\z/
 
       transaction = ::Braintree::Transaction.find(@payment.response_code)
       expect(transaction.status).to eq Braintree::Transaction::Status::Authorized
@@ -326,7 +326,7 @@ describe Spree::Gateway::BraintreeGateway do
     it 'return a success response with an authorization code' do
       result =  @gateway.purchase(500, @credit_card)
       expect(result.success?).to be true
-      expect(result.authorization).to match /\A\w{6}\z/
+      expect(result.authorization).to match /\A\w{8}\z/
       expect(Braintree::Transaction::Status::SubmittedForSettlement).to eq Braintree::Transaction.find(result.authorization).status
     end
 
@@ -364,7 +364,7 @@ describe Spree::Gateway::BraintreeGateway do
       @payment.process!
 
       expect(@payment.log_entries.size).to eq(1)
-      expect(@payment.response_code).to match /\A\w{6}\z/
+      expect(@payment.response_code).to match(/\A\w{8}\z/)
 
       transaction = Braintree::Transaction.find(@payment.response_code)
       expect(transaction.status).to eq Braintree::Transaction::Status::SubmittedForSettlement
@@ -390,7 +390,7 @@ describe Spree::Gateway::BraintreeGateway do
 
     # Let's get the payment record associated with the credit
     @payment = @order.payments.last
-    expect(@payment.response_code).to match /\A\w{6}\z/
+    expect(@payment.response_code).to match /\A\w{8}\z/
 
     transaction = ::Braintree::Transaction.find(@payment.response_code)
     expect(transaction.type).to eq Braintree::Transaction::Type::Credit
@@ -407,7 +407,7 @@ describe Spree::Gateway::BraintreeGateway do
     @payment.log_entries.size == 0
     @payment.process! # as done in PaymentsController#create
     @payment.log_entries.size == 1
-    expect(@payment.response_code).to match /\A\w{6}\z/
+    expect(@payment.response_code).to match /\A\w{8}\z/
     expect(@payment.state).to eq 'completed'
 
     transaction = ::Braintree::Transaction.find(@payment.response_code)

--- a/spec/models/gateway/pin_gateway_spec.rb
+++ b/spec/models/gateway/pin_gateway_spec.rb
@@ -48,7 +48,7 @@ describe Spree::Gateway::PinGateway do
   end
 
   it 'always uses purchase' do
-    @payment.should_receive(:purchase!)
+    expect(@payment).to receive(:purchase!)
     @payment.process!
   end
 end

--- a/spec/models/gateway/stripe_gateway_spec.rb
+++ b/spec/models/gateway/stripe_gateway_spec.rb
@@ -17,21 +17,21 @@ describe Spree::Gateway::StripeGateway do
 
   let(:provider) do
     double('provider').tap do |p|
-      p.stub(:purchase)
-      p.stub(:authorize)
-      p.stub(:capture)
+      allow(p).to receive(:purchase)
+      allow(p).to receive(:authorize)
+      allow(p).to receive(:capture)
     end
   end
 
   before do
     subject.preferences = { secret_key: secret_key }
-    subject.stub(:options_for_purchase_or_auth).and_return(['money','cc','opts'])
-    subject.stub(:provider).and_return provider
+    allow(subject).to receive(:options_for_purchase_or_auth).and_return(['money','cc','opts'])
+    allow(subject).to receive(:provider).and_return provider
   end
 
   describe '#create_profile' do
     before do
-      payment.source.stub(:update_attributes!)
+      allow(payment.source).to receive(:update_attributes!)
     end
 
     context 'with an order that has a bill address' do
@@ -47,7 +47,7 @@ describe Spree::Gateway::StripeGateway do
       }
 
       it 'stores the bill address with the provider' do
-        subject.provider.should_receive(:store).with(payment.source, {
+        expect(subject.provider).to receive(:store).with(payment.source, {
           email: email,
           login: secret_key,
 
@@ -69,7 +69,7 @@ describe Spree::Gateway::StripeGateway do
       let(:bill_address) { nil }
 
       it 'does not store a bill address with the provider' do
-        subject.provider.should_receive(:store).with(payment.source, {
+        expect(subject.provider).to receive(:store).with(payment.source, {
           email: email,
           login: secret_key,
         }).and_return double.as_null_object
@@ -81,7 +81,7 @@ describe Spree::Gateway::StripeGateway do
       context "correcting the card type" do
         before do
           # We don't care about this method for these tests
-          subject.provider.stub(:store).and_return(double.as_null_object)
+          allow(subject.provider).to receive(:store).and_return(double.as_null_object)
         end
 
         it "converts 'American Express' to 'american_express'" do
@@ -109,7 +109,7 @@ describe Spree::Gateway::StripeGateway do
       let(:bill_address) { nil }
 
       it 'stores the profile_id as a card' do
-        subject.provider.should_receive(:store).with(source.gateway_payment_profile_id, anything).and_return double.as_null_object
+        expect(subject.provider).to receive(:store).with(source.gateway_payment_profile_id, anything).and_return double.as_null_object
 
         subject.create_profile payment
       end
@@ -122,7 +122,7 @@ describe Spree::Gateway::StripeGateway do
     end
 
     it 'send the payment to the provider' do
-      provider.should_receive(:purchase).with('money','cc','opts')
+      expect(provider).to receive(:purchase).with('money','cc','opts')
     end
   end
 
@@ -132,7 +132,7 @@ describe Spree::Gateway::StripeGateway do
     end
 
     it 'send the authorization to the provider' do
-      provider.should_receive(:authorize).with('money','cc','opts')
+      expect(provider).to receive(:authorize).with('money','cc','opts')
     end
   end
 
@@ -143,11 +143,11 @@ describe Spree::Gateway::StripeGateway do
     end
 
     it 'convert the amount to cents' do
-      provider.should_receive(:capture).with(1234,anything,anything)
+      expect(provider).to receive(:capture).with(1234,anything,anything)
     end
 
     it 'use the response code as the authorization' do
-      provider.should_receive(:capture).with(anything,'response_code',anything)
+      expect(provider).to receive(:capture).with(anything,'response_code',anything)
     end
   end
 
@@ -155,9 +155,9 @@ describe Spree::Gateway::StripeGateway do
     let(:gateway) do
       gateway = described_class.new(active: true)
       gateway.set_preference :secret_key, secret_key
-      gateway.stub(:options_for_purchase_or_auth).and_return(['money','cc','opts'])
-      gateway.stub(:provider).and_return provider
-      gateway.stub :source_required => true
+      allow(gateway).to receive(:options_for_purchase_or_auth).and_return(['money','cc','opts'])
+      allow(gateway).to receive(:provider).and_return provider
+      allow(gateway).to receive_messages :source_required => true
       gateway
     end
 
@@ -192,7 +192,7 @@ describe Spree::Gateway::StripeGateway do
     end
 
     it 'gets correct amount' do
-      provider.should_receive(:capture).with(9855,'12345',anything).and_return(success_response)
+      expect(provider).to receive(:capture).with(9855,'12345',anything).and_return(success_response)
     end
   end
 end

--- a/spree_gateway.gemspec
+++ b/spree_gateway.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'poltergeist', '~> 1.6.0'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rspec-activemodel-mocks'
-  s.add_development_dependency 'rspec-rails', '~> 2.99'
+  s.add_development_dependency 'rspec-rails', '~> 3'
   s.add_development_dependency 'sass-rails', '~> 5.0.0'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'simplecov'


### PR DESCRIPTION
1. Create Payment Method for ApplePay, inherited from Stripe.
2. Add JS/CSS for ApplePay.
3. Fix Assets precompile path.
4. Add RSpecs.