### PR TITLE
Fixed failing stripe specs

### DIFF
--- a/spec/features/stripe_checkout_spec.rb
+++ b/spec/features/stripe_checkout_spec.rb
@@ -79,6 +79,7 @@ describe "Stripe checkout", type: :feature do
   it "shows an error with invalid security fields", :js => true do
     fill_in "Card Number", :with => "4242 4242 4242 4242"
     fill_in "Expiration", :with => "01 / #{Time.now.year + 1}"
+    fill_in "Card Code", :with => "99"
     click_button "Save and Continue"
     wait_for_stripe
     expect(page).to have_content("Your card's security code is invalid.")


### PR DESCRIPTION
Stripe currently ignores blank CVV codes so we need to pass 2 digit as an invalid code