### PR TITLE
Update checkout_controller_decorator.rb

### DIFF
--- a/lib/controllers/frontend/spree/checkout_controller_decorator.rb
+++ b/lib/controllers/frontend/spree/checkout_controller_decorator.rb
@@ -1,6 +1,6 @@
 module Spree
   CheckoutController.class_eval do
-    before_filter :confirm_skrill, :only => [:update]
+    before_action :confirm_skrill, :only => [:update]
 
     def skrill_return
 


### PR DESCRIPTION
Updated before_filter to before_action for rails 5.1 (replaced deprecated function)