### PR TITLE
Fixes Broken 2-4-Stable Test Suite

### DIFF
--- a/spree_gateway.gemspec
+++ b/spree_gateway.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'listen', '2.7.5'
   s.add_development_dependency 'guard-rspec', '~> 2.6'
   s.add_development_dependency 'launchy'
-  s.add_development_dependency 'mysql2'
+  s.add_development_dependency 'mysql2', '~> 0.3.17'
   s.add_development_dependency 'pg', '~> 0.17.1'
   s.add_development_dependency 'poltergeist', '~> 1.15.0'
   s.add_development_dependency 'pry'

--- a/spree_gateway.gemspec
+++ b/spree_gateway.gemspec
@@ -32,13 +32,16 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'guard-rspec', '~> 2.6'
   s.add_development_dependency 'launchy'
   s.add_development_dependency 'mysql2'
-  s.add_development_dependency 'pg'
+  s.add_development_dependency 'pg', '~> 0.17.1'
   s.add_development_dependency 'poltergeist', '~> 1.15.0'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rspec-activemodel-mocks'
   s.add_development_dependency 'rspec-rails', '~> 2.99'
   s.add_development_dependency 'sass-rails', '~> 4.0.2'
-  s.add_development_dependency 'selenium-webdriver'
+  s.add_development_dependency 'selenium-webdriver', '~> 2.44.0'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'
+
+  s.add_development_dependency 'addressable', '~> 2.3.6'
+  s.add_development_dependency 'mime-types', '~> 2.4.3'
 end


### PR DESCRIPTION
When I proposed #290, there were a variety of failures in the test matrix. This PR proposes to resolve them to ensure confidence in the gem on esoteric Ruby versions. 

- [x] Ruby 1.9.3/Postgres
- [x] Ruby 1.9.3/MySQL
- [x] Ruby 1.9.3/SQLite
- [x] Ruby 2.0.0/MySQL
- [x] Ruby 2.1.2/MySQL