### PR TITLE
3.4.1

### DIFF
--- a/lib/assets/javascripts/spree/frontend/spree_gateway.js
+++ b/lib/assets/javascripts/spree/frontend/spree_gateway.js
@@ -1,1 +1,0 @@
-//= require spree/frontend

--- a/lib/assets/stylesheets/spree/frontend/spree_gateway.css
+++ b/lib/assets/stylesheets/spree/frontend/spree_gateway.css
@@ -1,3 +1,0 @@
-/*
- *= require spree/frontend
-*/

--- a/lib/spree_gateway.rb
+++ b/lib/spree_gateway.rb
@@ -1,4 +1,3 @@
 require 'spree_core'
 require 'spree_gateway/engine'
-require 'sass/rails'
 require 'spree_extension'

--- a/lib/spree_gateway/engine.rb
+++ b/lib/spree_gateway/engine.rb
@@ -37,12 +37,6 @@ module SpreeGateway
     end
 
     def self.activate
-      if SpreeGateway::Engine.frontend_available?
-        Rails.application.config.assets.precompile += [
-          'lib/assets/javascripts/spree/frontend/spree_gateway.js',
-          'lib/assets/stylesheets/spree/frontend/spree_gateway.css',
-        ]
-      end
       Dir.glob(File.join(File.dirname(__FILE__), '../../app/**/spree/*_decorator*.rb')) do |c|
         Rails.application.config.cache_classes ? require(c) : load(c)
       end

--- a/spree_gateway.gemspec
+++ b/spree_gateway.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'puma'
   s.add_development_dependency 'rspec-activemodel-mocks'
   s.add_development_dependency 'rspec-rails'
+  s.add_development_dependency 'sass-rails'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'

--- a/spree_gateway.gemspec
+++ b/spree_gateway.gemspec
@@ -37,7 +37,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'puma'
   s.add_development_dependency 'rspec-activemodel-mocks'
   s.add_development_dependency 'rspec-rails'
-  s.add_development_dependency 'sass-rails', '>= 3.2'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'

--- a/spree_gateway.gemspec
+++ b/spree_gateway.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_gateway'
-  s.version     = '3.4.0'
+  s.version     = '3.4.1'
   s.summary     = 'Additional Payment Gateways for Spree Commerce'
   s.description = s.summary
 


### PR DESCRIPTION
- [X] drop sass requirement to work with Spree 3.7 and 4.0
- [X] don't generate useless empty asset files