### PR TITLE
Change payment confirmation step title

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,7 +13,7 @@ en:
     please_wait_for_confirmation_popup: Please wait for payment confirmation popup to appear.
     payment_successfully_authorized: The payment was successfully authorized.
     order_state:
-      payment_confirm: Payment confirmation
+      payment_confirm: Verify payment
     log_entry:
       braintree:
         message: Message


### PR DESCRIPTION
The previous payment confirmation step title was too long causing the progress bar to be not displayed properly. 