### PR TITLE
Fix loading of frontend decorators if frontend not available

### DIFF
--- a/lib/spree_gateway/engine.rb
+++ b/lib/spree_gateway/engine.rb
@@ -45,8 +45,10 @@ module SpreeGateway
         Rails.application.config.cache_classes ? require(c) : load(c)
       end
 
-      Dir.glob(File.join(File.dirname(__FILE__), '../../lib/spree_frontend/controllers/spree/*_decorator*.rb')) do |c|
-        Rails.application.config.cache_classes ? require(c) : load(c)
+      if self.frontend_available?
+        Dir.glob(File.join(File.dirname(__FILE__), '../../lib/spree_frontend/controllers/spree/*_decorator*.rb')) do |c|
+          Rails.application.config.cache_classes ? require(c) : load(c)
+        end
       end
     end
 


### PR DESCRIPTION
Previous fix added in #365 and released in 3.9.1 did not fix the issue of loading front end decorators when using spree in API only mode.

Have tested this fix locally and in a deployed environment. Seems to work fine.