### PR TITLE
[SD-1007] [BraintreeVZero] Verify the response from the payment provider responds to params

### DIFF
--- a/app/models/spree/payment_decorator.rb
+++ b/app/models/spree/payment_decorator.rb
@@ -1,7 +1,9 @@
 module Spree
   module PaymentDecorator
     def handle_response(response, success_state, failure_state)
-      self.intent_client_key = response.params['client_secret'] if response.params['client_secret'] && response.success?
+      if response.success? && response.respond_to?(:params)
+        self.intent_client_key = response.params['client_secret'] if response.params['client_secret']
+      end
       super
     end
 


### PR DESCRIPTION
This change is related to the https://github.com/spree-contrib/spree_braintree_vzero/pull/225
During checkout tests, i was unable to complete the checkout flow due to the different response from Braintree than expected. Because of that, every checkout ended up on the 500 error:

> NoMethodError in Spree::CheckoutController#update
> undefined method `params' for #<Braintree::SuccessfulResult:0x00007fbc435b7730>
