### PR TITLE
API for Stripe 3D Secure Payment confirmation keys

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Spree::Core::Engine.add_routes do
     namespace :v2 do
       namespace :storefront do
         namespace :intents do
+          post :payment_confirmation_data
           post :handle_response
         end
       end

--- a/lib/controllers/spree/api/v2/storefront/intents_controller.rb
+++ b/lib/controllers/spree/api/v2/storefront/intents_controller.rb
@@ -5,6 +5,24 @@ module Spree
         class IntentsController < ::Spree::Api::V2::BaseController
           include Spree::Api::V2::Storefront::OrderConcern
 
+          def payment_confirmation_data
+            spree_authorize! :update, spree_current_order, order_token
+
+            if spree_current_order.intents?
+              spree_current_order.process_payments!
+              spree_current_order.reload
+              last_valid_payment = spree_current_order.payments.valid.where.not(intent_client_key: nil).last
+
+              if last_valid_payment.present?
+                client_secret = last_valid_payment.intent_client_key
+                publishable_key = last_valid_payment.payment_method.preferred_publishable_key
+                return render json: { client_secret: client_secret, pk_key: publishable_key }, status: :ok
+              end
+            end
+
+            render json: { client_secret: nil, pk_key: nil }, status: :ok
+          end
+
           def handle_response
             if params['response']['error']
               invalidate_payment


### PR DESCRIPTION
To process 3D secure payments (e.g. via Stripe), we need to get a client secret and publishable key on the frontend. 

This is already done in the built in frontend (https://github.com/spree/spree_gateway/blob/master/lib/spree_frontend/controllers/spree/checkout_controller_decorator.rb#L7), but there's no way to trigger the same via the API.

In this PR I added an API V2 endpoint for the same action.

I think it would be a good idea to add some automated tests for this method + the already existing `handle_response` method in the same controller. I'm not sure how to get started with this, so I'd appreciate some hints regarding test data setup + what would be good to mock in these test ;)