### PR TITLE
Add publishable preferences for stripe payment methods

### DIFF
--- a/app/models/spree/gateway/stripe_elements_gateway.rb
+++ b/app/models/spree/gateway/stripe_elements_gateway.rb
@@ -54,7 +54,7 @@ module Spree
       return money, creditcard, options
     end
 
-    def publishable_preference_keys
+    def public_preference_keys
       %i[publishable_key test_mode intents]
     end
   end

--- a/app/models/spree/gateway/stripe_elements_gateway.rb
+++ b/app/models/spree/gateway/stripe_elements_gateway.rb
@@ -53,5 +53,9 @@ module Spree
       options[:execute_threed] = get_preference(:intents)
       return money, creditcard, options
     end
+
+    def publishable_preference_keys
+      %i[publishable_key test_mode intents]
+    end
   end
 end

--- a/app/models/spree/gateway/stripe_gateway.rb
+++ b/app/models/spree/gateway/stripe_gateway.rb
@@ -143,5 +143,9 @@ module Spree
       url = 'https://spreecommerce.org'
       "#{name_with_version} #{url}"
     end
+
+    def publishable_preference_keys
+      %i[publishable_key test_mode]
+    end
   end
 end

--- a/app/models/spree/gateway/stripe_gateway.rb
+++ b/app/models/spree/gateway/stripe_gateway.rb
@@ -144,7 +144,7 @@ module Spree
       "#{name_with_version} #{url}"
     end
 
-    def publishable_preference_keys
+    def public_preference_keys
       %i[publishable_key test_mode]
     end
   end


### PR DESCRIPTION
This is an implementation of Stripe's payment gateway definition for the following PR in spree/core: https://github.com/spree/spree/pull/11299