### PR TITLE
Change initialize process to be compatible with Rails 7

### DIFF
--- a/lib/spree_gateway/engine.rb
+++ b/lib/spree_gateway/engine.rb
@@ -4,7 +4,7 @@ module SpreeGateway
 
     config.autoload_paths += %W(#{config.root}/lib)
 
-    initializer "spree.gateway.payment_methods", :after => "spree.register.payment_methods" do |app|
+    config.after_initialize do |app|
       app.config.spree.payment_methods << Spree::Gateway::AuthorizeNet
       app.config.spree.payment_methods << Spree::Gateway::AuthorizeNetCim
       app.config.spree.payment_methods << Spree::Gateway::BalancedGateway


### PR DESCRIPTION
While trying to create sandbox application with Rails 7 I got `uninitialized constant Spree::Gateway` error.
This bug comes from Rails 7 autoloader changes ([link](https://rubyonrails.org/2021/9/3/autoloading-in-rails-7-get-ready)). The fix is to change initialize process.