### PR TITLE
[SP-120] Infer default country from Store

### DIFF
--- a/spec/models/gateway/braintree_gateway_spec.rb
+++ b/spec/models/gateway/braintree_gateway_spec.rb
@@ -80,7 +80,7 @@ describe Spree::Gateway::BraintreeGateway do
 
   describe 'payment profile failure' do
     before do
-      country = Spree::Country.default
+      country = Spree::Store.default.default_country
       state   = country.states.first
       address = create(:address,
         firstname: 'John',


### PR DESCRIPTION
### **What?**
[SP-120](https://upsidelab.atlassian.net/browse/SP-120)
Infer default country from Store instead of config.


### **Why?**
Spree no longer uses Spree::Config[:default_country_id] - it's now managed at per-store level.

[SP-120]: https://upsidelab.atlassian.net/browse/SP-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ