### PR TITLE
Restore `SpreeGateway.version` method

### DIFF
--- a/lib/spree_gateway/version.rb
+++ b/lib/spree_gateway/version.rb
@@ -1,6 +1,10 @@
 module SpreeGateway
   VERSION = '3.11.0'.freeze
 
+  def self.version
+    VERSION
+  end
+
   def gem_version
     Gem::Version.new(VERSION)
   end


### PR DESCRIPTION
Restores functionality to module `Spree::Gateway::StripeGateway#app_info` and anywhere else that used the old interface

Solves https://github.com/spree/spree_gateway/issues/418
